### PR TITLE
Disable unused `rand` feature in twox-hash crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ readme = "Readme.md"
 
 [dependencies]
 byteorder = "1.3.2"
-twox-hash = "1.5.0"
+twox-hash = { version = "1.5.0", default-features = false }


### PR DESCRIPTION
xxHash seems to only ever be used with a fixed seed. Disabling the `rand` feature stops pulling in `rand` and `libc` dependencies. Tests still pass.