### PR TITLE
Add a fuzzing target to verify interoperability with libzstd

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -8,6 +8,9 @@ publish = false
 [package.metadata]
 cargo-fuzz = true
 
+[dependencies]
+zstd = "0.5.1+zstd.1.4.4"
+
 [dependencies.ruzstd]
 path = ".."
 [dependencies.libfuzzer-sys]
@@ -20,3 +23,7 @@ members = ["."]
 [[bin]]
 name = "fuzz_target_1"
 path = "fuzz_targets/fuzz_target_1.rs"
+
+[[bin]]
+name = "interop"
+path = "fuzz_targets/interop.rs"

--- a/fuzz/fuzz_targets/interop.rs
+++ b/fuzz/fuzz_targets/interop.rs
@@ -1,0 +1,22 @@
+#![no_main]
+#[macro_use] extern crate libfuzzer_sys;
+extern crate ruzstd;
+use std::io::Read;
+
+fn decode_ruzstd(data: &mut dyn std::io::Read) -> Vec<u8> {
+    let mut decoder = ruzstd::StreamingDecoder::new(data).unwrap();
+    let mut result: Vec<u8> = Vec::new();
+    decoder.read_to_end(&mut result).expect("Decoding failed");
+    result
+}
+
+fn encode_zstd(data: &[u8]) -> Result<Vec<u8>, std::io::Error> {
+    zstd::stream::encode_all(std::io::Cursor::new(data), 3)
+}
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(compressed) = encode_zstd(data) {
+        let decoded = decode_ruzstd(&mut compressed.as_slice());
+        assert!(decoded == data, "Decoded data did not match the original input");
+    }
+});


### PR DESCRIPTION
Add a fuzzing target that verifies that that we can decompress any data compressed by the reference implementation. No failures detected after 200 million executions.