### PR TITLE
Remove hot calls to `memmove` by replacing `Vec<u8>` with `VecDeque<u8>`

### DIFF
--- a/src/decoding/decodebuffer.rs
+++ b/src/decoding/decodebuffer.rs
@@ -17,12 +17,7 @@ pub struct Decodebuffer {
 impl io::Read for Decodebuffer {
     fn read(&mut self, target: &mut [u8]) -> io::Result<usize> {
         let max_amount = self.can_drain_to_window_size().unwrap_or(0);
-
-        let amount = if max_amount > target.len() {
-            target.len()
-        } else {
-            max_amount
-        };
+        let amount = max_amount.min(target.len());
 
         let mut written = 0;
         self.drain_to(amount, |buf| {
@@ -224,11 +219,7 @@ impl Decodebuffer {
     }
 
     pub fn read_all(&mut self, target: &mut [u8]) -> io::Result<usize> {
-        let amount = if self.buffer.len() > target.len() {
-            target.len()
-        } else {
-            self.buffer.len()
-        };
+        let amount = self.buffer.len().min(target.len());
 
         let mut written = 0;
         self.drain_to(amount, |buf| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![deny(trivial_casts, trivial_numeric_casts, rust_2018_idioms)]
-#![forbid(unsafe_code)]
 
 pub mod blocks;
 pub mod decoding;


### PR DESCRIPTION
This removes the need to constantly `drain`, which is one of the hottest functions on the flamegraph.

From a quick benchmark on a large file decoding goes from about 10.5s to 3.5s. As a comparison zstd 1.4.8 takes 1.2s. We're getting closer :eyes:

## Before

![flamegraph](https://user-images.githubusercontent.com/6215781/161424348-c658b73a-9fcb-4e7b-9d76-261d041f7a5b.svg)

## After

![flamegraph](https://user-images.githubusercontent.com/6215781/161424447-ebc3d18a-1ebb-4269-9285-65df07f10386.svg)

