### PR TITLE
Decode multiple frames if present in each file

### DIFF
--- a/src/bin/zstd.rs
+++ b/src/bin/zstd.rs
@@ -1,8 +1,8 @@
 extern crate ruzstd;
 use std::fs::File;
 use std::io::Read;
-use std::io::Write;
 use std::io::Seek;
+use std::io::Write;
 
 struct StateTracker {
     bytes_used: u64,
@@ -86,29 +86,30 @@ fn main() {
                 result.resize(result.capacity(), 0);
             }
 
-            match frame_dec.get_checksum_from_data() {
-                Some(chksum) => {
-                    if frame_dec.get_calculated_checksum().unwrap() != chksum {
-                        tracker.invalid_checksums += 1;
-                        eprintln!(
-                            "Checksum did not match in frame {}! From data: {}, calculated while decoding: {}",
-                            tracker.frames_used,
-                            chksum,
-                            frame_dec.get_calculated_checksum().unwrap()
-                        );
-                    } else {
-                        tracker.valid_checksums += 1;
-                    }
+            if let Some(chksum) = frame_dec.get_checksum_from_data() {
+                if frame_dec.get_calculated_checksum().unwrap() != chksum {
+                    tracker.invalid_checksums += 1;
+                    eprintln!(
+                        "Checksum did not match in frame {}! From data: {}, calculated while decoding: {}",
+                        tracker.frames_used,
+                        chksum,
+                        frame_dec.get_calculated_checksum().unwrap()
+                    );
+                } else {
+                    tracker.valid_checksums += 1;
                 }
-                None => {},
             }
         }
 
-        eprintln!("\nDecoded frames: {}  bytes: {}", tracker.frames_used, tracker.bytes_used);
+        eprintln!(
+            "\nDecoded frames: {}  bytes: {}",
+            tracker.frames_used, tracker.bytes_used
+        );
         if tracker.valid_checksums == 0 && tracker.invalid_checksums == 0 {
             eprintln!("No checksums to test");
         } else {
-            eprintln!("{} of {} checksums are ok!",
+            eprintln!(
+                "{} of {} checksums are ok!",
                 tracker.valid_checksums,
                 tracker.valid_checksums + tracker.invalid_checksums,
             );

--- a/src/bin/zstd.rs
+++ b/src/bin/zstd.rs
@@ -2,9 +2,15 @@ extern crate ruzstd;
 use std::fs::File;
 use std::io::Read;
 use std::io::Write;
+use std::io::Seek;
 
 struct StateTracker {
     bytes_used: u64,
+    frames_used: usize,
+    valid_checksums: usize,
+    invalid_checksums: usize,
+    file_pos: u64,
+    file_size: u64,
     old_percentage: i8,
 }
 
@@ -34,64 +40,78 @@ fn main() {
     let mut frame_dec = ruzstd::FrameDecoder::new();
 
     for path in file_paths {
-        let mut tracker = StateTracker {
-            bytes_used: 0,
-            old_percentage: -1,
-        };
-
         eprintln!("File: {}", path);
         let mut f = File::open(path).unwrap();
 
-        frame_dec.reset(&mut f).unwrap();
+        let mut tracker = StateTracker {
+            bytes_used: 0,
+            frames_used: 0,
+            valid_checksums: 0,
+            invalid_checksums: 0,
+            file_size: f.metadata().unwrap().len(),
+            file_pos: 0,
+            old_percentage: -1,
+        };
 
         let batch_size = 1024 * 1024 * 10;
         let mut result = vec![0; batch_size];
 
-        while !frame_dec.is_finished() {
-            frame_dec
-                .decode_blocks(&mut f, ruzstd::BlockDecodingStrategy::UptoBytes(batch_size))
-                .unwrap();
+        while tracker.file_pos < tracker.file_size {
+            frame_dec.reset(&mut f).unwrap();
 
-            if frame_dec.can_collect() > batch_size {
+            tracker.frames_used += 1;
+
+            while !frame_dec.is_finished() {
+                frame_dec
+                    .decode_blocks(&mut f, ruzstd::BlockDecodingStrategy::UptoBytes(batch_size))
+                    .unwrap();
+
+                if frame_dec.can_collect() > batch_size {
+                    let x = frame_dec.read(result.as_mut_slice()).unwrap();
+                    tracker.file_pos = f.stream_position().unwrap();
+
+                    result.resize(x, 0);
+                    do_something(&result, &mut tracker);
+                    result.resize(result.capacity(), 0);
+                }
+            }
+
+            // handle the last chunk of data
+            while frame_dec.can_collect() > 0 {
                 let x = frame_dec.read(result.as_mut_slice()).unwrap();
+                tracker.file_pos = f.stream_position().unwrap();
 
                 result.resize(x, 0);
                 do_something(&result, &mut tracker);
                 result.resize(result.capacity(), 0);
+            }
 
-                let percentage = (tracker.bytes_used * 100) / frame_dec.content_size().unwrap();
-                if percentage as i8 != tracker.old_percentage {
-                    eprint!("\r");
-                    eprint!("{} % done", percentage);
-                    tracker.old_percentage = percentage as i8;
+            match frame_dec.get_checksum_from_data() {
+                Some(chksum) => {
+                    if frame_dec.get_calculated_checksum().unwrap() != chksum {
+                        tracker.invalid_checksums += 1;
+                        eprintln!(
+                            "Checksum did not match in frame {}! From data: {}, calculated while decoding: {}",
+                            tracker.frames_used,
+                            chksum,
+                            frame_dec.get_calculated_checksum().unwrap()
+                        );
+                    } else {
+                        tracker.valid_checksums += 1;
+                    }
                 }
+                None => {},
             }
         }
 
-        // handle the last chunk of data
-        while frame_dec.can_collect() > 0 {
-            let x = frame_dec.read(result.as_mut_slice()).unwrap();
-
-            result.resize(x, 0);
-            do_something(&result, &mut tracker);
-            result.resize(result.capacity(), 0);
-        }
-
-        eprintln!("\nDecoded bytes: {}", tracker.bytes_used);
-
-        match frame_dec.get_checksum_from_data() {
-            Some(chksum) => {
-                if frame_dec.get_calculated_checksum().unwrap() != chksum {
-                    eprintln!(
-                        "Checksum did not match! From data: {}, calculated while decoding: {}",
-                        chksum,
-                        frame_dec.get_calculated_checksum().unwrap()
-                    );
-                } else {
-                    eprintln!("Checksums are ok!");
-                }
-            }
-            None => eprintln!("No checksums to test"),
+        eprintln!("\nDecoded frames: {}  bytes: {}", tracker.frames_used, tracker.bytes_used);
+        if tracker.valid_checksums == 0 && tracker.invalid_checksums == 0 {
+            eprintln!("No checksums to test");
+        } else {
+            eprintln!("{} of {} checksums are ok!",
+                tracker.valid_checksums,
+                tracker.valid_checksums + tracker.invalid_checksums,
+            );
         }
     }
 }
@@ -100,4 +120,11 @@ fn do_something(data: &[u8], s: &mut StateTracker) {
     //Do something. Like writing it to a file or to stdout...
     std::io::stdout().write_all(data).unwrap();
     s.bytes_used += data.len() as u64;
+
+    let percentage = (s.file_pos * 100) / s.file_size;
+    if percentage as i8 != s.old_percentage {
+        eprint!("\r");
+        eprint!("{} % done", percentage);
+        s.old_percentage = percentage as i8;
+    }
 }


### PR DESCRIPTION
A file or stream may consist of more than one frame. Do not stop after the first frame when decoding in zstd. Continue reading until we reach the end of the file or we get an error.

Move percent-done output into do_something() to avoid duplicating code. Calculate the percentage as the ratio of bytes-in instead of bytes-out since we won't know the total bytes-out until we process the last frame.

Report the number of frames as well as the number of bytes at the end. Report total valid checksums at the end instead of per-frame.