### PR TITLE
Fix missing variable in error output

### DIFF
--- a/src/blocks/sequence_section.rs
+++ b/src/blocks/sequence_section.rs
@@ -58,7 +58,7 @@ impl Default for SequencesHeader {
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum SequencesHeaderParseError {
-    #[error("source must have at least {need_at_least} bytes to parse header; got {} bytes")]
+    #[error("source must have at least {need_at_least} bytes to parse header; got {got} bytes")]
     NotEnoughBytes { need_at_least: u8, got: usize },
 }
 


### PR DESCRIPTION
I noticed because the compiler complains about it.