### PR TITLE
zstd: Use range slices instead of resizing vectors

### DIFF
--- a/src/bin/zstd.rs
+++ b/src/bin/zstd.rs
@@ -69,10 +69,7 @@ fn main() {
                 if frame_dec.can_collect() > batch_size {
                     let x = frame_dec.read(result.as_mut_slice()).unwrap();
                     tracker.file_pos = f.stream_position().unwrap();
-
-                    result.resize(x, 0);
-                    do_something(&result, &mut tracker);
-                    result.resize(result.capacity(), 0);
+                    do_something(&result[..x], &mut tracker);
                 }
             }
 
@@ -80,10 +77,7 @@ fn main() {
             while frame_dec.can_collect() > 0 {
                 let x = frame_dec.read(result.as_mut_slice()).unwrap();
                 tracker.file_pos = f.stream_position().unwrap();
-
-                result.resize(x, 0);
-                do_something(&result, &mut tracker);
-                result.resize(result.capacity(), 0);
+                do_something(&result[..x], &mut tracker);
             }
 
             if let Some(chksum) = frame_dec.get_checksum_from_data() {


### PR DESCRIPTION
There should be no appreciable difference in runtime, but it seems friendlier and simpler to avoid specialty-mutations for the vector, especially since the function accepts a slice anyway.

--

This is so obvious and more idiomatic, I am curious if it was not done this way originally for a reason.  