### PR TITLE
Add support for no_std

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,77 @@ jobs:
           command: clippy
           args: -- -D warnings
 
+  check-no-std:
+    name: Check (no_std)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install nightly toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+
+      - name: Run cargo check without std feature
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          toolchain: nightly
+          args: --no-default-features
+
+  test-no-std:
+    name: Test Suite (no_std)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install nightly toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+
+      - name: Run cargo test without std feature
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          toolchain: nightly
+          args: --no-default-features
+
+  lints-no-std:
+    name: Lints
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install nightly toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+          components: rustfmt, clippy
+
+      - name: Run cargo fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          toolchain: nightly
+          args: --all -- --check
+
+      - name: Run cargo clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          toolchain: nightly
+          args: --no-default-features -- -D warnings
+
   # fails CI because criterion needs two versions of autocfg
   #cargo-deny:
   #  name: Cargo Deny

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,14 +11,26 @@ exclude = ["decodecorpus_files/*", "dict_tests/*", "fuzz_decodecorpus/*"]
 readme = "Readme.md"
 
 [dependencies]
-byteorder = "1.4"
+byteorder = { version = "1.4", default-features = false }
 twox-hash = { version = "1.6", default-features = false }
-thiserror = "1"
+thiserror = { package = "thiserror-core", version = "1.0.38", default-features = false }
 
 [dev-dependencies]
 criterion = "0.3"
 rand = "0.8.5"
 
+[features]
+default = ["std"]
+std = ["thiserror/std"]
+
 [[bench]]
 name = "reversedbitreader_bench"
 harness = false
+
+[[bin]]
+name = "zstd"
+required-features = ["std"]
+
+[[bin]]
+name = "zstd_stream"
+required-features = ["std"]

--- a/src/blocks/block.rs
+++ b/src/blocks/block.rs
@@ -6,8 +6,8 @@ pub enum BlockType {
     Reserved,
 }
 
-impl std::fmt::Display for BlockType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+impl core::fmt::Display for BlockType {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
         match self {
             BlockType::Compressed => write!(f, "Compressed"),
             BlockType::Raw => write!(f, "Raw"),

--- a/src/blocks/literals_section.rs
+++ b/src/blocks/literals_section.rs
@@ -25,8 +25,8 @@ pub enum LiteralsSectionParseError {
     NotEnoughBytes { have: usize, need: u8 },
 }
 
-impl std::fmt::Display for LiteralsSectionType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+impl core::fmt::Display for LiteralsSectionType {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
         match self {
             LiteralsSectionType::Compressed => write!(f, "Compressed"),
             LiteralsSectionType::Raw => write!(f, "Raw"),

--- a/src/blocks/sequence_section.rs
+++ b/src/blocks/sequence_section.rs
@@ -10,8 +10,8 @@ pub struct Sequence {
     pub of: u32,
 }
 
-impl std::fmt::Display for Sequence {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+impl core::fmt::Display for Sequence {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
         write!(f, "LL: {}, ML: {}, OF: {}", self.ll, self.ml, self.of)
     }
 }

--- a/src/decoding/dictionary.rs
+++ b/src/decoding/dictionary.rs
@@ -1,4 +1,5 @@
-use std::convert::TryInto;
+use alloc::vec::Vec;
+use core::convert::TryInto;
 
 use crate::decoding::scratch::FSEScratch;
 use crate::decoding::scratch::HuffmanScratch;

--- a/src/decoding/literals_section_decoder.rs
+++ b/src/decoding/literals_section_decoder.rs
@@ -2,6 +2,7 @@ use super::super::blocks::literals_section::{LiteralsSection, LiteralsSectionTyp
 use super::bit_reader_reverse::{BitReaderReversed, GetBitsError};
 use super::scratch::HuffmanScratch;
 use crate::huff0::{HuffmanDecoder, HuffmanDecoderError, HuffmanTableError};
+use alloc::vec::Vec;
 
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
@@ -75,9 +76,7 @@ fn decompress_literals(
         LiteralsSectionType::Compressed => {
             //read Huffman tree description
             bytes_read += scratch.table.build_decoder(source)?;
-            if crate::VERBOSE {
-                println!("Built huffman table using {} bytes", bytes_read);
-            }
+            vprintln!("Built huffman table using {} bytes", bytes_read);
         }
         LiteralsSectionType::Treeless => {
             if scratch.table.max_num_bits == 0 {

--- a/src/decoding/ringbuffer.rs
+++ b/src/decoding/ringbuffer.rs
@@ -1,4 +1,5 @@
-use std::{alloc::Layout, ptr::NonNull, slice};
+use alloc::alloc::{alloc, dealloc};
+use core::{alloc::Layout, ptr::NonNull, slice};
 
 pub struct RingBuffer {
     buf: NonNull<u8>,
@@ -70,7 +71,7 @@ impl RingBuffer {
         // alloc the new memory region and panic if alloc fails
         // TODO maybe rework this to generate an error?
         let new_buf = unsafe {
-            let new_buf = std::alloc::alloc(new_layout);
+            let new_buf = alloc(new_layout);
 
             NonNull::new(new_buf).expect("Allocating new space for the ringbuffer failed")
         };
@@ -85,7 +86,7 @@ impl RingBuffer {
                     .as_ptr()
                     .add(s1_len)
                     .copy_from_nonoverlapping(s2_ptr, s2_len);
-                std::alloc::dealloc(self.buf.as_ptr(), current_layout);
+                dealloc(self.buf.as_ptr(), current_layout);
             }
 
             self.tail = s1_len + s2_len;
@@ -341,7 +342,7 @@ impl Drop for RingBuffer {
         let current_layout = unsafe { Layout::array::<u8>(self.cap).unwrap_unchecked() };
 
         unsafe {
-            std::alloc::dealloc(self.buf.as_ptr(), current_layout);
+            dealloc(self.buf.as_ptr(), current_layout);
         }
     }
 }
@@ -448,8 +449,8 @@ unsafe fn copy_with_nobranch_check(
             f1_ptr.copy_from_nonoverlapping(m1_ptr, m1_in_f1);
             f2_ptr.copy_from_nonoverlapping(m1_ptr.add(m1_in_f1), m1_in_f2);
         }
-        6 => std::hint::unreachable_unchecked(),
-        7 => std::hint::unreachable_unchecked(),
+        6 => core::hint::unreachable_unchecked(),
+        7 => core::hint::unreachable_unchecked(),
         9 => {
             f1_ptr.copy_from_nonoverlapping(m1_ptr, m1_in_f1);
             f2_ptr.copy_from_nonoverlapping(m2_ptr, m2_in_f2);
@@ -480,9 +481,9 @@ unsafe fn copy_with_nobranch_check(
                 .add(m1_in_f2)
                 .copy_from_nonoverlapping(m2_ptr, m2_in_f2);
         }
-        14 => std::hint::unreachable_unchecked(),
-        15 => std::hint::unreachable_unchecked(),
-        _ => std::hint::unreachable_unchecked(),
+        14 => core::hint::unreachable_unchecked(),
+        15 => core::hint::unreachable_unchecked(),
+        _ => core::hint::unreachable_unchecked(),
     }
 }
 

--- a/src/decoding/scratch.rs
+++ b/src/decoding/scratch.rs
@@ -3,6 +3,7 @@ use super::decodebuffer::Decodebuffer;
 use crate::decoding::dictionary::Dictionary;
 use crate::fse::FSETable;
 use crate::huff0::HuffmanTable;
+use alloc::vec::Vec;
 
 pub struct DecoderScratch {
     pub huf: HuffmanScratch,

--- a/src/decoding/sequence_execution.rs
+++ b/src/decoding/sequence_execution.rs
@@ -18,8 +18,6 @@ pub fn execute_sequences(scratch: &mut DecoderScratch) -> Result<(), ExecuteSequ
 
     for idx in 0..scratch.sequences.len() {
         let seq = scratch.sequences[idx];
-        if crate::VERBOSE {}
-        //println!("{}: {}", idx, seq);
 
         if seq.ll > 0 {
             let high = literals_copy_counter + seq.ll as usize;

--- a/src/decoding/sequence_section_decoder.rs
+++ b/src/decoding/sequence_section_decoder.rs
@@ -4,6 +4,7 @@ use super::super::blocks::sequence_section::SequencesHeader;
 use super::bit_reader_reverse::{BitReaderReversed, GetBitsError};
 use super::scratch::FSEScratch;
 use crate::fse::{FSEDecoder, FSEDecoderError, FSETableError};
+use alloc::vec::Vec;
 
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
@@ -42,9 +43,7 @@ pub fn decode_sequences(
 ) -> Result<(), DecodeSequenceError> {
     let bytes_read = maybe_update_fse_tables(section, source, scratch)?;
 
-    if crate::VERBOSE {
-        println!("Updating tables used {} bytes", bytes_read);
-    }
+    vprintln!("Updating tables used {} bytes", bytes_read);
 
     let bit_stream = &source[bytes_read..];
 
@@ -319,16 +318,13 @@ fn maybe_update_fse_tables(
         ModeType::FSECompressed => {
             let bytes = scratch.literal_lengths.build_decoder(source, LL_MAX_LOG)?;
             bytes_read += bytes;
-            if crate::VERBOSE {
-                println!("Updating ll table");
-                println!("Used bytes: {}", bytes);
-            }
+
+            vprintln!("Updating ll table");
+            vprintln!("Used bytes: {}", bytes);
             scratch.ll_rle = None;
         }
         ModeType::RLE => {
-            if crate::VERBOSE {
-                println!("Use RLE ll table");
-            }
+            vprintln!("Use RLE ll table");
             if source.is_empty() {
                 return Err(DecodeSequenceError::MissingByteForRleLlTable);
             }
@@ -336,9 +332,7 @@ fn maybe_update_fse_tables(
             scratch.ll_rle = Some(source[0]);
         }
         ModeType::Predefined => {
-            if crate::VERBOSE {
-                println!("Use predefined ll table");
-            }
+            vprintln!("Use predefined ll table");
             scratch.literal_lengths.build_from_probabilities(
                 LL_DEFAULT_ACC_LOG,
                 &Vec::from(&LITERALS_LENGTH_DEFAULT_DISTRIBUTION[..]),
@@ -346,9 +340,7 @@ fn maybe_update_fse_tables(
             scratch.ll_rle = None;
         }
         ModeType::Repeat => {
-            if crate::VERBOSE {
-                println!("Repeat ll table");
-            }
+            vprintln!("Repeat ll table");
             /* Nothing to do */
         }
     };
@@ -358,17 +350,13 @@ fn maybe_update_fse_tables(
     match modes.of_mode() {
         ModeType::FSECompressed => {
             let bytes = scratch.offsets.build_decoder(of_source, OF_MAX_LOG)?;
-            if crate::VERBOSE {
-                println!("Updating of table");
-                println!("Used bytes: {}", bytes);
-            }
+            vprintln!("Updating of table");
+            vprintln!("Used bytes: {}", bytes);
             bytes_read += bytes;
             scratch.of_rle = None;
         }
         ModeType::RLE => {
-            if crate::VERBOSE {
-                println!("Use RLE of table");
-            }
+            vprintln!("Use RLE of table");
             if of_source.is_empty() {
                 return Err(DecodeSequenceError::MissingByteForRleOfTable);
             }
@@ -376,9 +364,7 @@ fn maybe_update_fse_tables(
             scratch.of_rle = Some(of_source[0]);
         }
         ModeType::Predefined => {
-            if crate::VERBOSE {
-                println!("Use predefined of table");
-            }
+            vprintln!("Use predefined of table");
             scratch.offsets.build_from_probabilities(
                 OF_DEFAULT_ACC_LOG,
                 &Vec::from(&OFFSET_DEFAULT_DISTRIBUTION[..]),
@@ -386,9 +372,7 @@ fn maybe_update_fse_tables(
             scratch.of_rle = None;
         }
         ModeType::Repeat => {
-            if crate::VERBOSE {
-                println!("Repeat of table");
-            }
+            vprintln!("Repeat of table");
             /* Nothing to do */
         }
     };
@@ -399,16 +383,12 @@ fn maybe_update_fse_tables(
         ModeType::FSECompressed => {
             let bytes = scratch.match_lengths.build_decoder(ml_source, ML_MAX_LOG)?;
             bytes_read += bytes;
-            if crate::VERBOSE {
-                println!("Updating ml table");
-                println!("Used bytes: {}", bytes);
-            }
+            vprintln!("Updating ml table");
+            vprintln!("Used bytes: {}", bytes);
             scratch.ml_rle = None;
         }
         ModeType::RLE => {
-            if crate::VERBOSE {
-                println!("Use RLE ml table");
-            }
+            vprintln!("Use RLE ml table");
             if ml_source.is_empty() {
                 return Err(DecodeSequenceError::MissingByteForRleMlTable);
             }
@@ -416,9 +396,7 @@ fn maybe_update_fse_tables(
             scratch.ml_rle = Some(ml_source[0]);
         }
         ModeType::Predefined => {
-            if crate::VERBOSE {
-                println!("Use predefined ml table");
-            }
+            vprintln!("Use predefined ml table");
             scratch.match_lengths.build_from_probabilities(
                 ML_DEFAULT_ACC_LOG,
                 &Vec::from(&MATCH_LENGTH_DEFAULT_DISTRIBUTION[..]),
@@ -426,9 +404,7 @@ fn maybe_update_fse_tables(
             scratch.ml_rle = None;
         }
         ModeType::Repeat => {
-            if crate::VERBOSE {
-                println!("Repeat ml table");
-            }
+            vprintln!("Repeat ml table");
             /* Nothing to do */
         }
     };
@@ -463,10 +439,14 @@ fn test_ll_default() {
         )
         .unwrap();
 
+    #[cfg(feature = "std")]
     for idx in 0..table.decode.len() {
-        println!(
+        std::println!(
             "{:3}: {:3} {:3} {:3}",
-            idx, table.decode[idx].symbol, table.decode[idx].num_bits, table.decode[idx].base_line
+            idx,
+            table.decode[idx].symbol,
+            table.decode[idx].num_bits,
+            table.decode[idx].base_line
         );
     }
 

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -1,5 +1,8 @@
-use std::convert::TryInto;
-use std::io;
+use crate::io::{Error, Read};
+use core::convert::TryInto;
+
+use alloc::vec;
+use alloc::vec::Vec;
 
 pub const MAGIC_NUM: u32 = 0xFD2F_B528;
 pub const MIN_WINDOW_SIZE: u64 = 1024;
@@ -214,22 +217,21 @@ impl Frame {
 #[non_exhaustive]
 pub enum ReadFrameHeaderError {
     #[error("Error while reading magic number: {0}")]
-    MagicNumberReadError(#[source] io::Error),
+    MagicNumberReadError(#[source] Error),
     #[error("Error while reading frame descriptor: {0}")]
-    FrameDescriptorReadError(#[source] io::Error),
+    FrameDescriptorReadError(#[source] Error),
     #[error(transparent)]
     InvalidFrameDescriptor(#[from] FrameDescriptorError),
     #[error("Error while reading window descriptor: {0}")]
-    WindowDescriptorReadError(#[source] io::Error),
+    WindowDescriptorReadError(#[source] Error),
     #[error("Error while reading dictionary id: {0}")]
-    DictionaryIdReadError(#[source] io::Error),
+    DictionaryIdReadError(#[source] Error),
     #[error("Error while reading frame content size: {0}")]
-    FrameContentSizeReadError(#[source] io::Error),
+    FrameContentSizeReadError(#[source] Error),
     #[error("SkippableFrame encountered with MagicNumber 0x{0:X} and length {1} bytes")]
     SkipFrame(u32, u32),
 }
 
-use std::io::Read;
 pub fn read_frame_header(mut r: impl Read) -> Result<(Frame, u8), ReadFrameHeaderError> {
     use ReadFrameHeaderError as err;
     let mut buf = [0u8; 4];

--- a/src/fse/fse_decoder.rs
+++ b/src/fse/fse_decoder.rs
@@ -1,5 +1,6 @@
 use crate::decoding::bit_reader::BitReader;
 use crate::decoding::bit_reader_reverse::{BitReaderReversed, GetBitsError};
+use alloc::vec::Vec;
 
 #[derive(Clone)]
 pub struct FSETable {

--- a/src/huff0/huff0_decoder.rs
+++ b/src/huff0/huff0_decoder.rs
@@ -1,5 +1,6 @@
 use crate::decoding::bit_reader_reverse::{BitReaderReversed, GetBitsError};
 use crate::fse::{FSEDecoder, FSEDecoderError, FSETable, FSETableError};
+use alloc::vec::Vec;
 
 #[derive(Clone)]
 pub struct HuffmanTable {
@@ -182,12 +183,10 @@ impl HuffmanTable {
                     });
                 }
 
-                if crate::VERBOSE {
-                    println!(
-                        "Building fse table for huffman weights used: {}",
-                        bytes_used_by_fse_header
-                    );
-                }
+                vprintln!(
+                    "Building fse table for huffman weights used: {}",
+                    bytes_used_by_fse_header
+                );
                 let mut dec1 = FSEDecoder::new(&self.fse_table);
                 let mut dec2 = FSEDecoder::new(&self.fse_table);
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,0 +1,2 @@
+#[cfg(feature = "std")]
+pub use std::io::{Error, ErrorKind, Read, Write};

--- a/src/io_nostd.rs
+++ b/src/io_nostd.rs
@@ -1,0 +1,152 @@
+use alloc::boxed::Box;
+
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
+pub enum ErrorKind {
+    Interrupted,
+    UnexpectedEof,
+    WouldBlock,
+    Other,
+}
+
+impl ErrorKind {
+    fn as_str(&self) -> &'static str {
+        use ErrorKind::*;
+        match *self {
+            Interrupted => "operation interrupted",
+            UnexpectedEof => "unexpected end of file",
+            WouldBlock => "operation would block",
+            Other => "other error",
+        }
+    }
+}
+
+impl core::fmt::Display for ErrorKind {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[derive(Debug)]
+pub struct Error {
+    kind: ErrorKind,
+    err: Option<Box<dyn core::error::Error + Send + Sync>>,
+}
+
+impl Error {
+    pub fn new<E>(kind: ErrorKind, err: E) -> Self
+    where
+        E: Into<Box<dyn core::error::Error + Send + Sync>>,
+    {
+        Self {
+            kind,
+            err: Some(err.into()),
+        }
+    }
+
+    pub fn from(kind: ErrorKind) -> Self {
+        Self { kind, err: None }
+    }
+
+    pub fn kind(&self) -> ErrorKind {
+        self.kind
+    }
+
+    pub fn get_ref(&self) -> Option<&(dyn core::error::Error + Send + Sync + 'static)> {
+        self.err.as_ref().map(|e| e.as_ref())
+    }
+
+    pub fn get_mut(&mut self) -> Option<&mut (dyn core::error::Error + Send + Sync + 'static)> {
+        self.err.as_mut().map(|e| e.as_mut())
+    }
+
+    pub fn into_inner(self) -> Option<Box<dyn core::error::Error + Send + Sync>> {
+        self.err
+    }
+}
+
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(self.kind.as_str())?;
+
+        if let Some(ref e) = self.err {
+            e.fmt(f)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl core::error::Error for Error {}
+
+impl From<ErrorKind> for Error {
+    fn from(value: ErrorKind) -> Self {
+        Self::from(value)
+    }
+}
+
+pub trait Read {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Error>;
+
+    fn read_exact(&mut self, mut buf: &mut [u8]) -> Result<(), Error> {
+        while !buf.is_empty() {
+            match self.read(buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    let tmp = buf;
+                    buf = &mut tmp[n..];
+                }
+                Err(ref e) if e.kind() == ErrorKind::Interrupted => {}
+                Err(e) => return Err(e),
+            }
+        }
+        if !buf.is_empty() {
+            Err(Error::from(ErrorKind::UnexpectedEof))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl Read for &[u8] {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
+        let size = core::cmp::min(self.len(), buf.len());
+        let (to_copy, rest) = self.split_at(size);
+
+        if size == 1 {
+            buf[0] = to_copy[0];
+        } else {
+            buf[..size].copy_from_slice(to_copy);
+        }
+
+        *self = rest;
+        Ok(size)
+    }
+}
+
+impl<'a, T> Read for &'a mut T
+where
+    T: Read,
+{
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
+        (*self).read(buf)
+    }
+}
+
+pub trait Write {
+    fn write(&mut self, buf: &[u8]) -> Result<usize, Error>;
+    fn flush(&mut self) -> Result<(), Error>;
+}
+
+impl<'a, T> Write for &'a mut T
+where
+    T: Write,
+{
+    fn write(&mut self, buf: &[u8]) -> Result<usize, Error> {
+        (*self).write(buf)
+    }
+
+    fn flush(&mut self) -> Result<(), Error> {
+        (*self).flush()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,23 @@
+#![no_std]
 #![deny(trivial_casts, trivial_numeric_casts, rust_2018_idioms)]
+#![cfg_attr(not(feature = "std"), feature(error_in_core))]
+
+#[cfg(feature = "std")]
+extern crate std;
+
+extern crate alloc;
+
+#[cfg(feature = "std")]
+pub const VERBOSE: bool = false;
+
+macro_rules! vprintln {
+    ($($x:expr),*) => {
+        #[cfg(feature = "std")]
+        if crate::VERBOSE {
+            std::println!($($x),*);
+        }
+    }
+}
 
 pub mod blocks;
 pub mod decoding;
@@ -9,7 +28,15 @@ pub mod huff0;
 pub mod streaming_decoder;
 mod tests;
 
-pub const VERBOSE: bool = false;
+#[cfg(feature = "std")]
+pub mod io;
+
+#[cfg(not(feature = "std"))]
+pub mod io_nostd;
+
+#[cfg(not(feature = "std"))]
+pub use io_nostd as io;
+
 pub use frame_decoder::BlockDecodingStrategy;
 pub use frame_decoder::FrameDecoder;
 pub use streaming_decoder::StreamingDecoder;

--- a/src/streaming_decoder.rs
+++ b/src/streaming_decoder.rs
@@ -1,5 +1,5 @@
 use crate::frame_decoder::{BlockDecodingStrategy, FrameDecoder, FrameDecoderError};
-use std::io::Read;
+use crate::io::{Error, ErrorKind, Read};
 
 /// High level decoder that implements a io::Read that can be used with
 /// io::Read::read_to_end / io::Read::read_exact or passing this to another library / module as a source for the decoded content
@@ -32,7 +32,7 @@ impl<READ: Read> StreamingDecoder<READ> {
 }
 
 impl<READ: Read> Read for StreamingDecoder<READ> {
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
         if self.decoder.is_finished() && self.decoder.can_collect() == 0 {
             //No more bytes can ever be decoded
             return Ok(0);
@@ -52,9 +52,9 @@ impl<READ: Read> Read for StreamingDecoder<READ> {
             ) {
                 Ok(_) => { /*Nothing to do*/ }
                 Err(e) => {
-                    let err = std::io::Error::new(
-                        std::io::ErrorKind::Other,
-                        format!("Error in the zstd decoder: {:?}", e),
+                    let err = Error::new(
+                        ErrorKind::Other,
+                        alloc::format!("Error in the zstd decoder: {:?}", e),
                     );
                     return Err(err);
                 }

--- a/src/tests/decode_corpus.rs
+++ b/src/tests/decode_corpus.rs
@@ -1,8 +1,13 @@
 #[test]
 fn test_decode_corpus_files() {
+    extern crate std;
     use crate::frame_decoder;
+    use alloc::borrow::ToOwned;
+    use alloc::string::{String, ToString};
+    use alloc::vec::Vec;
     use std::fs;
     use std::io::Read;
+    use std::println;
 
     let mut success_counter = 0;
     let mut fail_counter_diff = 0;

--- a/src/tests/dict_test.rs
+++ b/src/tests/dict_test.rs
@@ -1,6 +1,7 @@
 #[test]
 fn test_dict_parsing() {
     use crate::decoding::dictionary::Dictionary;
+    use alloc::vec;
     let mut raw = vec![0u8; 8];
 
     // correct magic num
@@ -75,9 +76,14 @@ fn test_dict_parsing() {
 
 #[test]
 fn test_dict_decoding() {
+    extern crate std;
     use crate::frame_decoder;
+    use alloc::borrow::ToOwned;
+    use alloc::string::{String, ToString};
+    use alloc::vec::Vec;
     use std::fs;
     use std::io::Read;
+    use std::println;
 
     let mut success_counter = 0;
     let mut fail_counter_diff = 0;

--- a/src/tests/fuzz_regressions.rs
+++ b/src/tests/fuzz_regressions.rs
@@ -1,6 +1,8 @@
 #[test]
 fn test_all_artifacts() {
+    extern crate std;
     use crate::frame_decoder;
+    use std::borrow::ToOwned;
     use std::fs;
     use std::fs::File;
 


### PR DESCRIPTION
This PR adds the "std" default feature, and allows the crate to be build with no_std by disabling it.

Most changes are straightforward, changing imports to use core and alloc equivalents over std. Beyond that,

- Uses of `std::error::Error` are conditionally replaced with `core::error::Error`. This is currently unstable, so nightly is required for no_std usage for the time being. I believe it is still not possible to build a no_std binary without nightly, so this should be an acceptable requirement.
- `thiserror` has been replaced with a fork `thiserror-core`, that supports no_std. [A PR](https://github.com/dtolnay/thiserror/pull/211) is open on the original to support it, but has yet to be merged. This library also makes use of `core::error::Error`, and thus requires nightly when no_std is used.
- I was unable to create a set of traits that could serve as Read/Write in no_std and be blanked impl'd as their std counterparts when the std feature is enabled. As an alternative, I did the following:
  - `std::io::{Read, Write, Error, ErrorKind}` are re-exported under `crate::io` when std is enabled.
  - When std is disabled, a separate no_std implementation of the above is exported to `crate::io`.
  - I have not implemented every trait method on Read or Write in the no_std case, only those necessary. The remaining ones can be implemented by downstream users off of `read` or `write` directly if needed.
- Tests are modified to run against either the std or no_std build. They are probably going to be run on a target with std support, and as such import std themselves. I've also added an extra test case that does not make use of std.
- Verbose println statements are moved into a macro, which is conditionally enabled on the std feature.
- I have added additional CI pipelines to check, test, and lint the no_std build of the crate.
- The binaries in this crate have not been changed to support no_std, they just instead depend on the std feature being enabled.

I've tested this in a baremetal i386 project of mine with success. Haven't tried the webassembly use case.

Resolves #15 