### PR TITLE
Fix lint errors

### DIFF
--- a/benches/reversedbitreader_bench.rs
+++ b/benches/reversedbitreader_bench.rs
@@ -5,7 +5,7 @@ use ruzstd::decoding::bit_reader_reverse::BitReaderReversed;
 fn do_all_accesses(br: &mut BitReaderReversed, accesses: &[u8]) -> u64 {
     let mut sum = 0;
     for x in accesses {
-        sum += br.get_bits(*x).unwrap() as u64;
+        sum += br.get_bits(*x).unwrap();
     }
     let _ = black_box(br);
     sum

--- a/src/decoding/ringbuffer.rs
+++ b/src/decoding/ringbuffer.rs
@@ -268,8 +268,6 @@ impl RingBuffer {
     /// 2. More then len reserved space so we do not write out-of-bounds
     #[warn(unsafe_op_in_unsafe_fn)]
     pub unsafe fn extend_from_within_unchecked(&mut self, start: usize, len: usize) {
-        debug_assert!(!self.buf.as_ptr().is_null());
-
         if self.head < self.tail {
             // continous data slice  |____HDDDDDDDT_____|
             let after_tail = usize::min(len, self.cap - self.tail);

--- a/src/tests/fuzz_regressions.rs
+++ b/src/tests/fuzz_regressions.rs
@@ -17,12 +17,10 @@ fn test_all_artifacts() {
         }
 
         let mut f = File::open(file_name.clone()).unwrap();
-        match frame_dec.reset(&mut f) {
-            Ok(_) => {
-                let _ = frame_dec.decode_blocks(&mut f, frame_decoder::BlockDecodingStrategy::All);
-                /* ignore errors. It just should never panic on invalid input */
-            }
-            Err(_) => {} /* ignore errors. It just should never panic on invalid input */
-        }
+
+        /* ignore errors. It just should never panic on invalid input */
+        let _: Result<_, _> = frame_dec.reset(&mut f).and_then(|()| {
+            frame_dec.decode_blocks(&mut f, frame_decoder::BlockDecodingStrategy::All)
+        });
     }
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -351,8 +351,7 @@ fn test_streaming_no_std() {
     let mut stream = crate::streaming_decoder::StreamingDecoder::new(&mut content).unwrap();
 
     let original = include_bytes!("../../decodecorpus_files/z000088");
-    let mut result = Vec::new();
-    result.resize(original.len(), 0);
+    let mut result = vec![0; original.len()];
     Read::read_exact(&mut stream, &mut result).unwrap();
 
     if original.len() != result.len() {
@@ -391,8 +390,7 @@ fn test_streaming_no_std() {
             .unwrap();
 
     let original = include_bytes!("../../decodecorpus_files/z000068");
-    let mut result = Vec::new();
-    result.resize(original.len(), 0);
+    let mut result = vec![0; original.len()];
     Read::read_exact(&mut stream, &mut result).unwrap();
 
     std::println!("Results for file:");


### PR DESCRIPTION
- Remove useless assertion
- Avoid single-match expression
- Avoid slow zero-filling initialization
- Avoid unnecessary cast
