### PR TITLE
Make twox-hash an optional dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,15 +12,16 @@ readme = "Readme.md"
 
 [dependencies]
 byteorder = { version = "1.5", default-features = false }
-twox-hash = { version = "1.6", default-features = false }
+twox-hash = { version = "1.6", default-features = false, optional = true }
 derive_more = { version = "0.99", default-features = false, features = ["display", "from"] }
 
 [dev-dependencies]
 criterion = "0.3"
-rand = {version = "0.8.5", features = ["small_rng"]}
+rand = { version = "0.8.5", features = ["small_rng"] }
 
 [features]
-default = ["std"]
+default = ["hash", "std"]
+hash = ["dep:twox-hash"]
 std = ["derive_more/error"]
 
 [[bench]]

--- a/src/bin/zstd.rs
+++ b/src/bin/zstd.rs
@@ -95,6 +95,7 @@ fn main() {
                 do_something(&result[..x], &mut tracker);
             }
 
+            #[cfg(feature = "hash")]
             if let Some(chksum) = frame_dec.get_checksum_from_data() {
                 if frame_dec.get_calculated_checksum().unwrap() != chksum {
                     tracker.invalid_checksums += 1;

--- a/src/decoding/decodebuffer.rs
+++ b/src/decoding/decodebuffer.rs
@@ -1,8 +1,7 @@
 use crate::io::{Error, Read, Write};
 use alloc::vec::Vec;
+#[cfg(feature = "hash")]
 use core::hash::Hasher;
-
-use twox_hash::XxHash64;
 
 use super::ringbuffer::RingBuffer;
 
@@ -12,7 +11,8 @@ pub struct Decodebuffer {
 
     pub window_size: usize,
     total_output_counter: u64,
-    pub hash: XxHash64,
+    #[cfg(feature = "hash")]
+    pub hash: twox_hash::XxHash64,
 }
 
 #[derive(Debug, derive_more::Display)]
@@ -47,7 +47,8 @@ impl Decodebuffer {
             dict_content: Vec::new(),
             window_size,
             total_output_counter: 0,
-            hash: XxHash64::with_seed(0),
+            #[cfg(feature = "hash")]
+            hash: Default::default(),
         }
     }
 
@@ -57,7 +58,10 @@ impl Decodebuffer {
         self.buffer.reserve(self.window_size);
         self.dict_content.clear();
         self.total_output_counter = 0;
-        self.hash = XxHash64::with_seed(0);
+        #[cfg(feature = "hash")]
+        {
+            self.hash = Default::default();
+        }
     }
 
     pub fn len(&self) -> usize {
@@ -208,8 +212,11 @@ impl Decodebuffer {
     //drain the buffer completely
     pub fn drain(&mut self) -> Vec<u8> {
         let (slice1, slice2) = self.buffer.as_slices();
-        self.hash.write(slice1);
-        self.hash.write(slice2);
+        #[cfg(feature = "hash")]
+        {
+            self.hash.write(slice1);
+            self.hash.write(slice2);
+        }
 
         let mut vec = Vec::with_capacity(slice1.len() + slice2.len());
         vec.extend_from_slice(slice1);
@@ -273,6 +280,7 @@ impl Decodebuffer {
 
         if n1 != 0 {
             let (written1, res1) = write_bytes(&slice1[..n1]);
+            #[cfg(feature = "hash")]
             self.hash.write(&slice1[..written1]);
             drain_guard.amount += written1;
 
@@ -283,6 +291,7 @@ impl Decodebuffer {
             // Partial writes SHOULD never happen without res1 being an error, but lets just protect against it anyways.
             if written1 == n1 && n2 != 0 {
                 let (written2, res2) = write_bytes(&slice2[..n2]);
+                #[cfg(feature = "hash")]
                 self.hash.write(&slice2[..written2]);
                 drain_guard.amount += written2;
 

--- a/src/frame_decoder.rs
+++ b/src/frame_decoder.rs
@@ -6,7 +6,6 @@ use crate::io::{Error, Read, Write};
 use alloc::collections::BTreeMap;
 use alloc::vec::Vec;
 use core::convert::TryInto;
-use core::hash::Hasher;
 
 /// This implements a decoder for zstd frames. This decoder is able to decode frames only partially and gives control
 /// over how many bytes/blocks will be decoded at a time (so you don't have to decode a 10GB file into memory all at once).
@@ -256,7 +255,10 @@ impl FrameDecoder {
 
     /// Returns the checksum that was calculated while decoding.
     /// Only a sensible value after all decoded bytes have been collected/read from the FrameDecoder
+    #[cfg(feature = "hash")]
     pub fn get_calculated_checksum(&self) -> Option<u32> {
+        use core::hash::Hasher;
+
         let state = match &self.state {
             None => return None,
             Some(s) => s,

--- a/src/tests/decode_corpus.rs
+++ b/src/tests/decode_corpus.rs
@@ -13,6 +13,7 @@ fn test_decode_corpus_files() {
     let mut fail_counter_diff = 0;
     let mut fail_counter_size = 0;
     let mut fail_counter_bytes_read = 0;
+    #[cfg_attr(not(feature = "hash"), allow(unused_mut))]
     let mut fail_counter_chksum = 0;
     let mut total_counter = 0;
     let mut failed: Vec<String> = Vec::new();
@@ -57,6 +58,7 @@ fn test_decode_corpus_files() {
 
         match frame_dec.get_checksum_from_data() {
             Some(chksum) => {
+                #[cfg(feature = "hash")]
                 if frame_dec.get_calculated_checksum().unwrap() != chksum {
                     println!(
                         "Checksum did not match! From data: {}, calculated while decoding: {}\n",
@@ -68,6 +70,11 @@ fn test_decode_corpus_files() {
                 } else {
                     println!("Checksums are ok!\n");
                 }
+                #[cfg(not(feature = "hash"))]
+                println!(
+                    "Checksum feature not enabled, skipping. From data: {}\n",
+                    chksum
+                );
             }
             None => println!("No checksums to test\n"),
         }

--- a/src/tests/dict_test.rs
+++ b/src/tests/dict_test.rs
@@ -133,6 +133,7 @@ fn test_dict_decoding() {
 
         match frame_dec.get_checksum_from_data() {
             Some(chksum) => {
+                #[cfg(feature = "hash")]
                 if frame_dec.get_calculated_checksum().unwrap() != chksum {
                     println!(
                         "Checksum did not match! From data: {}, calculated while decoding: {}\n",
@@ -142,6 +143,11 @@ fn test_dict_decoding() {
                 } else {
                     println!("Checksums are ok!\n");
                 }
+                #[cfg(not(feature = "hash"))]
+                println!(
+                    "Checksum feature not enabled, skipping. From data: {}\n",
+                    chksum
+                );
             }
             None => println!("No checksums to test\n"),
         }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -161,6 +161,7 @@ fn test_decode_from_to() {
 
     match frame_dec.get_checksum_from_data() {
         Some(chksum) => {
+            #[cfg(feature = "hash")]
             if frame_dec.get_calculated_checksum().unwrap() != chksum {
                 std::println!(
                     "Checksum did not match! From data: {}, calculated while decoding: {}\n",
@@ -170,6 +171,11 @@ fn test_decode_from_to() {
             } else {
                 std::println!("Checksums are ok!\n");
             }
+            #[cfg(not(feature = "hash"))]
+            std::println!(
+                "Checksum feature not enabled, skipping. From data: {}\n",
+                chksum
+            );
         }
         None => std::println!("No checksums to test\n"),
     }


### PR DESCRIPTION
Add a new feature "hash" which pulls in twox-hash and hashes during
decoding. Add "hash" to default features.

Fixes #52.
