### PR TITLE
Implement accessors for inner reader on StreamDecoder

### DIFF
--- a/src/streaming_decoder.rs
+++ b/src/streaming_decoder.rs
@@ -39,8 +39,39 @@ impl<READ: Read> StreamingDecoder<READ, FrameDecoder> {
         decoder.init(&mut source)?;
         Ok(StreamingDecoder { decoder, source })
     }
+}
 
-    pub fn inner(self) -> FrameDecoder {
+impl<READ: Read, DEC: BorrowMut<FrameDecoder>> StreamingDecoder<READ, DEC> {
+    /// Gets a reference to the underlying reader.
+    pub fn get_ref(&self) -> &READ {
+        &self.source
+    }
+
+    /// Gets a mutable reference to the underlying reader.
+    ///
+    /// It is inadvisable to directly read from the underlying reader.
+    pub fn get_mut(&mut self) -> &mut READ {
+        &mut self.source
+    }
+
+    /// Destructures this object into the inner reader.
+    pub fn into_inner(self) -> READ
+    where
+        READ: Sized,
+    {
+        self.source
+    }
+
+    /// Destructures this object into both the inner reader and [FrameDecoder].
+    pub fn into_parts(self) -> (READ, DEC)
+    where
+        READ: Sized,
+    {
+        (self.source, self.decoder)
+    }
+
+    /// Destructures this object into the inner [FrameDecoder].
+    pub fn into_frame_decoder(self) -> DEC {
         self.decoder
     }
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -331,9 +331,11 @@ fn test_streaming() {
     // Test resetting to a new file while keeping the old decoder
 
     let mut content = fs::File::open("./decodecorpus_files/z000068.zst").unwrap();
-    let mut stream =
-        crate::streaming_decoder::StreamingDecoder::new_with_decoder(&mut content, stream.inner())
-            .unwrap();
+    let mut stream = crate::streaming_decoder::StreamingDecoder::new_with_decoder(
+        &mut content,
+        stream.into_frame_decoder(),
+    )
+    .unwrap();
 
     let mut result = Vec::new();
     Read::read_to_end(&mut stream, &mut result).unwrap();
@@ -415,9 +417,11 @@ fn test_streaming_no_std() {
 
     let content = include_bytes!("../../decodecorpus_files/z000068.zst");
     let mut content = content.as_slice();
-    let mut stream =
-        crate::streaming_decoder::StreamingDecoder::new_with_decoder(&mut content, stream.inner())
-            .unwrap();
+    let mut stream = crate::streaming_decoder::StreamingDecoder::new_with_decoder(
+        &mut content,
+        stream.into_frame_decoder(),
+    )
+    .unwrap();
 
     let original = include_bytes!("../../decodecorpus_files/z000068");
     let mut result = vec![0; original.len()];


### PR DESCRIPTION
I have an application where I access the inner Read object to get some statistics on how far we've read. This adds `get_ref` and `get_mut`, and another one where you can destructure to get both the Read and FrameDecoder.