### PR TITLE
Revert "remove derive_more (#60)"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ categories = ["compression"]
 [dependencies]
 byteorder = { version = "1.5", default-features = false }
 twox-hash = { version = "1.6", default-features = false, optional = true }
+derive_more = { version = "0.99", default-features = false, features = ["display", "from"] }
 
 [dev-dependencies]
 criterion = "0.5"
@@ -23,7 +24,7 @@ rand = { version = "0.8.5", features = ["small_rng"] }
 [features]
 default = ["hash", "std"]
 hash = ["dep:twox-hash"]
-std = []
+std = ["derive_more/error"]
 
 [[bench]]
 name = "reversedbitreader_bench"

--- a/src/blocks/literals_section.rs
+++ b/src/blocks/literals_section.rs
@@ -42,49 +42,19 @@ pub enum LiteralsSectionType {
     Treeless,
 }
 
-#[derive(Debug)]
+#[derive(Debug, derive_more::Display, derive_more::From)]
+#[cfg_attr(feature = "std", derive(derive_more::Error))]
 #[non_exhaustive]
 pub enum LiteralsSectionParseError {
+    #[display(fmt = "Illegal literalssectiontype. Is: {got}, must be in: 0, 1, 2, 3")]
     IllegalLiteralSectionType { got: u8 },
+    #[display(fmt = "{_0:?}")]
+    #[from]
     GetBitsError(GetBitsError),
+    #[display(
+        fmt = "Not enough byte to parse the literals section header. Have: {have}, Need: {need}"
+    )]
     NotEnoughBytes { have: usize, need: u8 },
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for LiteralsSectionParseError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            LiteralsSectionParseError::GetBitsError(source) => Some(source),
-            _ => None,
-        }
-    }
-}
-impl core::fmt::Display for LiteralsSectionParseError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            LiteralsSectionParseError::IllegalLiteralSectionType { got } => {
-                write!(
-                    f,
-                    "Illegal literalssectiontype. Is: {}, must be in: 0, 1, 2, 3",
-                    got
-                )
-            }
-            LiteralsSectionParseError::GetBitsError(e) => write!(f, "{:?}", e),
-            LiteralsSectionParseError::NotEnoughBytes { have, need } => {
-                write!(
-                    f,
-                    "Not enough byte to parse the literals section header. Have: {}, Need: {}",
-                    have, need,
-                )
-            }
-        }
-    }
-}
-
-impl From<GetBitsError> for LiteralsSectionParseError {
-    fn from(val: GetBitsError) -> Self {
-        Self::GetBitsError(val)
-    }
 }
 
 impl core::fmt::Display for LiteralsSectionType {

--- a/src/blocks/sequence_section.rs
+++ b/src/blocks/sequence_section.rs
@@ -92,27 +92,14 @@ impl Default for SequencesHeader {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, derive_more::Display)]
+#[cfg_attr(feature = "std", derive(derive_more::Error))]
 #[non_exhaustive]
 pub enum SequencesHeaderParseError {
+    #[display(
+        fmt = "source must have at least {need_at_least} bytes to parse header; got {got} bytes"
+    )]
     NotEnoughBytes { need_at_least: u8, got: usize },
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for SequencesHeaderParseError {}
-
-impl core::fmt::Display for SequencesHeaderParseError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            SequencesHeaderParseError::NotEnoughBytes { need_at_least, got } => {
-                write!(
-                    f,
-                    "source must have at least {} bytes to parse header; got {} bytes",
-                    need_at_least, got,
-                )
-            }
-        }
-    }
 }
 
 impl SequencesHeader {

--- a/src/decoding/bit_reader.rs
+++ b/src/decoding/bit_reader.rs
@@ -4,47 +4,19 @@ pub struct BitReader<'s> {
     source: &'s [u8],
 }
 
-#[derive(Debug)]
+#[derive(Debug, derive_more::Display)]
+#[cfg_attr(feature = "std", derive(derive_more::Error))]
 #[non_exhaustive]
 pub enum GetBitsError {
+    #[display(
+        fmt = "Cant serve this request. The reader is limited to {limit} bits, requested {num_requested_bits} bits"
+    )]
     TooManyBits {
         num_requested_bits: usize,
         limit: u8,
     },
-    NotEnoughRemainingBits {
-        requested: usize,
-        remaining: usize,
-    },
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for GetBitsError {}
-
-impl core::fmt::Display for GetBitsError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            GetBitsError::TooManyBits {
-                num_requested_bits,
-                limit,
-            } => {
-                write!(
-                    f,
-                    "Cant serve this request. The reader is limited to {} bits, requested {} bits",
-                    limit, num_requested_bits,
-                )
-            }
-            GetBitsError::NotEnoughRemainingBits {
-                requested,
-                remaining,
-            } => {
-                write!(
-                    f,
-                    "Can\'t read {} bits, only have {} bits left",
-                    requested, remaining,
-                )
-            }
-        }
-    }
+    #[display(fmt = "Can't read {requested} bits, only have {remaining} bits left")]
+    NotEnoughRemainingBits { requested: usize, remaining: usize },
 }
 
 impl<'s> BitReader<'s> {

--- a/src/decoding/block_decoder.rs
+++ b/src/decoding/block_decoder.rs
@@ -25,243 +25,89 @@ enum DecoderState {
     Failed, //TODO put "self.internal_state = DecoderState::Failed;" everywhere an unresolvable error occurs
 }
 
-#[derive(Debug)]
+#[derive(Debug, derive_more::Display, derive_more::From)]
+#[cfg_attr(feature = "std", derive(derive_more::Error))]
 #[non_exhaustive]
 pub enum BlockHeaderReadError {
+    #[display(fmt = "Error while reading the block header")]
+    #[from]
     ReadError(io::Error),
+    #[display(fmt = "Reserved block occured. This is considered corruption by the documentation")]
     FoundReservedBlock,
+    #[display(fmt = "Error getting block type: {_0}")]
+    #[from]
     BlockTypeError(BlockTypeError),
+    #[display(fmt = "Error getting block content size: {_0}")]
+    #[from]
     BlockSizeError(BlockSizeError),
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for BlockHeaderReadError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            BlockHeaderReadError::ReadError(source) => Some(source),
-            BlockHeaderReadError::BlockTypeError(source) => Some(source),
-            BlockHeaderReadError::BlockSizeError(source) => Some(source),
-            BlockHeaderReadError::FoundReservedBlock => None,
-        }
-    }
-}
-
-impl ::core::fmt::Display for BlockHeaderReadError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        match self {
-            BlockHeaderReadError::ReadError(_) => write!(f, "Error while reading the block header"),
-            BlockHeaderReadError::FoundReservedBlock => write!(
-                f,
-                "Reserved block occured. This is considered corruption by the documentation"
-            ),
-            BlockHeaderReadError::BlockTypeError(e) => write!(f, "Error getting block type: {}", e),
-            BlockHeaderReadError::BlockSizeError(e) => {
-                write!(f, "Error getting block content size: {}", e)
-            }
-        }
-    }
-}
-
-impl From<io::Error> for BlockHeaderReadError {
-    fn from(val: io::Error) -> Self {
-        Self::ReadError(val)
-    }
-}
-
-impl From<BlockTypeError> for BlockHeaderReadError {
-    fn from(val: BlockTypeError) -> Self {
-        Self::BlockTypeError(val)
-    }
-}
-
-impl From<BlockSizeError> for BlockHeaderReadError {
-    fn from(val: BlockSizeError) -> Self {
-        Self::BlockSizeError(val)
-    }
-}
-
-#[derive(Debug)]
+#[derive(Debug, derive_more::Display)]
+#[cfg_attr(feature = "std", derive(derive_more::Error))]
 #[non_exhaustive]
 pub enum BlockTypeError {
+    #[display(
+        fmt = "Invalid Blocktype number. Is: {num} Should be one of: 0, 1, 2, 3 (3 is reserved though"
+    )]
     InvalidBlocktypeNumber { num: u8 },
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for BlockTypeError {}
-
-impl core::fmt::Display for BlockTypeError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            BlockTypeError::InvalidBlocktypeNumber { num } => {
-                write!(f,
-                    "Invalid Blocktype number. Is: {} Should be one of: 0, 1, 2, 3 (3 is reserved though",
-                    num,
-                )
-            }
-        }
-    }
-}
-
-#[derive(Debug)]
+#[derive(Debug, derive_more::Display)]
+#[cfg_attr(feature = "std", derive(derive_more::Error))]
 #[non_exhaustive]
 pub enum BlockSizeError {
+    #[display(
+        fmt = "Blocksize was bigger than the absolute maximum {ABSOLUTE_MAXIMUM_BLOCK_SIZE} (128kb). Is: {size}"
+    )]
     BlockSizeTooLarge { size: u32 },
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for BlockSizeError {}
-
-impl core::fmt::Display for BlockSizeError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            BlockSizeError::BlockSizeTooLarge { size } => {
-                write!(
-                    f,
-                    "Blocksize was bigger than the absolute maximum {} (128kb). Is: {}",
-                    ABSOLUTE_MAXIMUM_BLOCK_SIZE, size,
-                )
-            }
-        }
-    }
-}
-
-#[derive(Debug)]
+#[derive(Debug, derive_more::Display, derive_more::From)]
+#[cfg_attr(feature = "std", derive(derive_more::Error))]
 #[non_exhaustive]
 pub enum DecompressBlockError {
+    #[display(fmt = "Error while reading the block content: {_0}")]
+    #[from]
     BlockContentReadError(io::Error),
+    #[display(
+        fmt = "Malformed section header. Says literals would be this long: {expected_len} but there are only {remaining_bytes} bytes left"
+    )]
     MalformedSectionHeader {
         expected_len: usize,
         remaining_bytes: usize,
     },
+    #[display(fmt = "{_0:?}")]
+    #[from]
     DecompressLiteralsError(DecompressLiteralsError),
+    #[display(fmt = "{_0:?}")]
+    #[from]
     LiteralsSectionParseError(LiteralsSectionParseError),
+    #[display(fmt = "{_0:?}")]
+    #[from]
     SequencesHeaderParseError(SequencesHeaderParseError),
+    #[display(fmt = "{_0:?}")]
+    #[from]
     DecodeSequenceError(DecodeSequenceError),
+    #[display(fmt = "{_0:?}")]
+    #[from]
     ExecuteSequencesError(ExecuteSequencesError),
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for DecompressBlockError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            DecompressBlockError::BlockContentReadError(source) => Some(source),
-            DecompressBlockError::DecompressLiteralsError(source) => Some(source),
-            DecompressBlockError::LiteralsSectionParseError(source) => Some(source),
-            DecompressBlockError::SequencesHeaderParseError(source) => Some(source),
-            DecompressBlockError::DecodeSequenceError(source) => Some(source),
-            DecompressBlockError::ExecuteSequencesError(source) => Some(source),
-            _ => None,
-        }
-    }
-}
-
-impl core::fmt::Display for DecompressBlockError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            DecompressBlockError::BlockContentReadError(e) => {
-                write!(f, "Error while reading the block content: {}", e)
-            }
-            DecompressBlockError::MalformedSectionHeader {
-                expected_len,
-                remaining_bytes,
-            } => {
-                write!(f,
-                    "Malformed section header. Says literals would be this long: {} but there are only {} bytes left",
-                    expected_len,
-                    remaining_bytes,
-                )
-            }
-            DecompressBlockError::DecompressLiteralsError(e) => write!(f, "{:?}", e),
-            DecompressBlockError::LiteralsSectionParseError(e) => write!(f, "{:?}", e),
-            DecompressBlockError::SequencesHeaderParseError(e) => write!(f, "{:?}", e),
-            DecompressBlockError::DecodeSequenceError(e) => write!(f, "{:?}", e),
-            DecompressBlockError::ExecuteSequencesError(e) => write!(f, "{:?}", e),
-        }
-    }
-}
-
-impl From<io::Error> for DecompressBlockError {
-    fn from(val: io::Error) -> Self {
-        Self::BlockContentReadError(val)
-    }
-}
-
-impl From<DecompressLiteralsError> for DecompressBlockError {
-    fn from(val: DecompressLiteralsError) -> Self {
-        Self::DecompressLiteralsError(val)
-    }
-}
-
-impl From<LiteralsSectionParseError> for DecompressBlockError {
-    fn from(val: LiteralsSectionParseError) -> Self {
-        Self::LiteralsSectionParseError(val)
-    }
-}
-
-impl From<SequencesHeaderParseError> for DecompressBlockError {
-    fn from(val: SequencesHeaderParseError) -> Self {
-        Self::SequencesHeaderParseError(val)
-    }
-}
-
-impl From<DecodeSequenceError> for DecompressBlockError {
-    fn from(val: DecodeSequenceError) -> Self {
-        Self::DecodeSequenceError(val)
-    }
-}
-
-impl From<ExecuteSequencesError> for DecompressBlockError {
-    fn from(val: ExecuteSequencesError) -> Self {
-        Self::ExecuteSequencesError(val)
-    }
-}
-
-#[derive(Debug)]
+#[derive(Debug, derive_more::Display, derive_more::From)]
+#[cfg_attr(feature = "std", derive(derive_more::Error))]
 #[non_exhaustive]
 pub enum DecodeBlockContentError {
+    #[display(fmt = "Can't decode next block if failed along the way. Results will be nonsense")]
     DecoderStateIsFailed,
+    #[display(
+        fmt = "Cant decode next block body, while expecting to decode the header of the previous block. Results will be nonsense"
+    )]
     ExpectedHeaderOfPreviousBlock,
+    #[display(fmt = "Error while reading bytes for {step}: {source}")]
     ReadError { step: BlockType, source: io::Error },
+    #[display(fmt = "{_0:?}")]
+    #[from]
     DecompressBlockError(DecompressBlockError),
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for DecodeBlockContentError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            DecodeBlockContentError::ReadError { step: _, source } => Some(source),
-            DecodeBlockContentError::DecompressBlockError(source) => Some(source),
-            _ => None,
-        }
-    }
-}
-
-impl core::fmt::Display for DecodeBlockContentError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            DecodeBlockContentError::DecoderStateIsFailed => {
-                write!(
-                    f,
-                    "Can't decode next block if failed along the way. Results will be nonsense",
-                )
-            }
-            DecodeBlockContentError::ExpectedHeaderOfPreviousBlock => {
-                write!(f,
-                            "Can't decode next block body, while expecting to decode the header of the previous block. Results will be nonsense",
-                        )
-            }
-            DecodeBlockContentError::ReadError { step, source } => {
-                write!(f, "Error while reading bytes for {}: {}", step, source,)
-            }
-            DecodeBlockContentError::DecompressBlockError(e) => write!(f, "{:?}", e),
-        }
-    }
-}
-
-impl From<DecompressBlockError> for DecodeBlockContentError {
-    fn from(val: DecompressBlockError) -> Self {
-        Self::DecompressBlockError(val)
-    }
 }
 
 /// Create a new [BlockDecoder].

--- a/src/decoding/decodebuffer.rs
+++ b/src/decoding/decodebuffer.rs
@@ -15,31 +15,14 @@ pub struct DecodeBuffer {
     pub hash: twox_hash::XxHash64,
 }
 
-#[derive(Debug)]
+#[derive(Debug, derive_more::Display)]
+#[cfg_attr(feature = "std", derive(derive_more::Error))]
 #[non_exhaustive]
 pub enum DecodeBufferError {
+    #[display(fmt = "Need {need} bytes from the dictionary but it is only {got} bytes long")]
     NotEnoughBytesInDictionary { got: usize, need: usize },
+    #[display(fmt = "offset: {offset} bigger than buffer: {buf_len}")]
     OffsetTooBig { offset: usize, buf_len: usize },
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for DecodeBufferError {}
-
-impl core::fmt::Display for DecodeBufferError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            DecodeBufferError::NotEnoughBytesInDictionary { got, need } => {
-                write!(
-                    f,
-                    "Need {} bytes from the dictionary but it is only {} bytes long",
-                    need, got,
-                )
-            }
-            DecodeBufferError::OffsetTooBig { offset, buf_len } => {
-                write!(f, "offset: {} bigger than buffer: {}", offset, buf_len,)
-            }
-        }
-    }
 }
 
 impl Read for DecodeBuffer {

--- a/src/decoding/dictionary.rs
+++ b/src/decoding/dictionary.rs
@@ -37,51 +37,20 @@ pub struct Dictionary {
     pub offset_hist: [u32; 3],
 }
 
-#[derive(Debug)]
+#[derive(Debug, derive_more::Display, derive_more::From)]
+#[cfg_attr(feature = "std", derive(derive_more::Error))]
 #[non_exhaustive]
 pub enum DictionaryDecodeError {
+    #[display(
+        fmt = "Bad magic_num at start of the dictionary; Got: {got:#04X?}, Expected: {MAGIC_NUM:#04x?}"
+    )]
     BadMagicNum { got: [u8; 4] },
+    #[display(fmt = "{_0:?}")]
+    #[from]
     FSETableError(FSETableError),
+    #[display(fmt = "{_0:?}")]
+    #[from]
     HuffmanTableError(HuffmanTableError),
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for DictionaryDecodeError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            DictionaryDecodeError::FSETableError(source) => Some(source),
-            DictionaryDecodeError::HuffmanTableError(source) => Some(source),
-            _ => None,
-        }
-    }
-}
-
-impl core::fmt::Display for DictionaryDecodeError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            DictionaryDecodeError::BadMagicNum { got } => {
-                write!(
-                    f,
-                    "Bad magic_num at start of the dictionary; Got: {:#04X?}, Expected: {:#04x?}",
-                    got, MAGIC_NUM,
-                )
-            }
-            DictionaryDecodeError::FSETableError(e) => write!(f, "{:?}", e),
-            DictionaryDecodeError::HuffmanTableError(e) => write!(f, "{:?}", e),
-        }
-    }
-}
-
-impl From<FSETableError> for DictionaryDecodeError {
-    fn from(val: FSETableError) -> Self {
-        Self::FSETableError(val)
-    }
-}
-
-impl From<HuffmanTableError> for DictionaryDecodeError {
-    fn from(val: HuffmanTableError) -> Self {
-        Self::HuffmanTableError(val)
-    }
 }
 
 /// This 4 byte (little endian) magic number refers to the start of a dictionary

--- a/src/decoding/sequence_execution.rs
+++ b/src/decoding/sequence_execution.rs
@@ -1,47 +1,16 @@
 use super::{decodebuffer::DecodeBufferError, scratch::DecoderScratch};
 
-#[derive(Debug)]
+#[derive(Debug, derive_more::Display, derive_more::From)]
+#[cfg_attr(feature = "std", derive(derive_more::Error))]
 #[non_exhaustive]
 pub enum ExecuteSequencesError {
+    #[display(fmt = "{_0:?}")]
+    #[from]
     DecodebufferError(DecodeBufferError),
+    #[display(fmt = "Sequence wants to copy up to byte {wanted}. Bytes in literalsbuffer: {have}")]
     NotEnoughBytesForSequence { wanted: usize, have: usize },
+    #[display(fmt = "Illegal offset: 0 found")]
     ZeroOffset,
-}
-
-impl core::fmt::Display for ExecuteSequencesError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            ExecuteSequencesError::DecodebufferError(e) => {
-                write!(f, "{:?}", e)
-            }
-            ExecuteSequencesError::NotEnoughBytesForSequence { wanted, have } => {
-                write!(
-                    f,
-                    "Sequence wants to copy up to byte {}. Bytes in literalsbuffer: {}",
-                    wanted, have
-                )
-            }
-            ExecuteSequencesError::ZeroOffset => {
-                write!(f, "Illegal offset: 0 found")
-            }
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for ExecuteSequencesError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            ExecuteSequencesError::DecodebufferError(source) => Some(source),
-            _ => None,
-        }
-    }
-}
-
-impl From<DecodeBufferError> for ExecuteSequencesError {
-    fn from(val: DecodeBufferError) -> Self {
-        Self::DecodebufferError(val)
-    }
 }
 
 /// Take the provided decoder and execute the sequences stored within

--- a/src/decoding/sequence_section_decoder.rs
+++ b/src/decoding/sequence_section_decoder.rs
@@ -9,96 +9,39 @@ use crate::blocks::sequence_section::{
 use crate::fse::{FSEDecoder, FSEDecoderError, FSETableError};
 use alloc::vec::Vec;
 
-#[derive(Debug)]
+#[derive(Debug, derive_more::Display, derive_more::From)]
+#[cfg_attr(feature = "std", derive(derive_more::Error))]
 #[non_exhaustive]
 pub enum DecodeSequenceError {
+    #[display(fmt = "{_0:?}")]
+    #[from]
     GetBitsError(GetBitsError),
+    #[display(fmt = "{_0:?}")]
+    #[from]
     FSEDecoderError(FSEDecoderError),
+    #[display(fmt = "{_0:?}")]
+    #[from]
     FSETableError(FSETableError),
+    #[display(
+        fmt = "Padding at the end of the sequence_section was more than a byte long: {skipped_bits} bits. Probably caused by data corruption"
+    )]
     ExtraPadding { skipped_bits: i32 },
+    #[display(fmt = "Do not support offsets bigger than 1<<32; got: {offset_code}")]
     UnsupportedOffset { offset_code: u8 },
+    #[display(fmt = "Read an offset == 0. That is an illegal value for offsets")]
     ZeroOffset,
+    #[display(fmt = "Bytestream did not contain enough bytes to decode num_sequences")]
     NotEnoughBytesForNumSequences,
+    #[display(fmt = "Did not use full bitstream. Bits left: {bits_remaining} ({} bytes)", bits_remaining / 8)]
     ExtraBits { bits_remaining: isize },
+    #[display(fmt = "compression modes are none but they must be set to something")]
     MissingCompressionMode,
+    #[display(fmt = "Need a byte to read for RLE ll table")]
     MissingByteForRleLlTable,
+    #[display(fmt = "Need a byte to read for RLE of table")]
     MissingByteForRleOfTable,
+    #[display(fmt = "Need a byte to read for RLE ml table")]
     MissingByteForRleMlTable,
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for DecodeSequenceError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            DecodeSequenceError::GetBitsError(source) => Some(source),
-            DecodeSequenceError::FSEDecoderError(source) => Some(source),
-            DecodeSequenceError::FSETableError(source) => Some(source),
-            _ => None,
-        }
-    }
-}
-
-impl core::fmt::Display for DecodeSequenceError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            DecodeSequenceError::GetBitsError(e) => write!(f, "{:?}", e),
-            DecodeSequenceError::FSEDecoderError(e) => write!(f, "{:?}", e),
-            DecodeSequenceError::FSETableError(e) => write!(f, "{:?}", e),
-            DecodeSequenceError::ExtraPadding { skipped_bits } => {
-                write!(f,
-                    "Padding at the end of the sequence_section was more than a byte long: {} bits. Probably caused by data corruption",
-                    skipped_bits,
-                )
-            }
-            DecodeSequenceError::UnsupportedOffset { offset_code } => {
-                write!(
-                    f,
-                    "Do not support offsets bigger than 1<<32; got: {}",
-                    offset_code,
-                )
-            }
-            DecodeSequenceError::ZeroOffset => write!(
-                f,
-                "Read an offset == 0. That is an illegal value for offsets"
-            ),
-            DecodeSequenceError::NotEnoughBytesForNumSequences => write!(
-                f,
-                "Bytestream did not contain enough bytes to decode num_sequences"
-            ),
-            DecodeSequenceError::ExtraBits { bits_remaining } => write!(f, "{}", bits_remaining),
-            DecodeSequenceError::MissingCompressionMode => write!(
-                f,
-                "compression modes are none but they must be set to something"
-            ),
-            DecodeSequenceError::MissingByteForRleLlTable => {
-                write!(f, "Need a byte to read for RLE ll table")
-            }
-            DecodeSequenceError::MissingByteForRleOfTable => {
-                write!(f, "Need a byte to read for RLE of table")
-            }
-            DecodeSequenceError::MissingByteForRleMlTable => {
-                write!(f, "Need a byte to read for RLE ml table")
-            }
-        }
-    }
-}
-
-impl From<GetBitsError> for DecodeSequenceError {
-    fn from(val: GetBitsError) -> Self {
-        Self::GetBitsError(val)
-    }
-}
-
-impl From<FSETableError> for DecodeSequenceError {
-    fn from(val: FSETableError) -> Self {
-        Self::FSETableError(val)
-    }
-}
-
-impl From<FSEDecoderError> for DecodeSequenceError {
-    fn from(val: FSEDecoderError) -> Self {
-        Self::FSEDecoderError(val)
-    }
 }
 
 /// Decode the provided source as a series of sequences into the supplied `target`.

--- a/src/frame_decoder.rs
+++ b/src/frame_decoder.rs
@@ -10,8 +10,6 @@ use crate::io::{Error, Read, Write};
 use alloc::collections::BTreeMap;
 use alloc::vec::Vec;
 use core::convert::TryInto;
-#[cfg(feature = "std")]
-use std::error::Error as StdError;
 
 /// This implements a decoder for zstd frames. This decoder is able to decode frames only partially and gives control
 /// over how many bytes/blocks will be decoded at a time (so you don't have to decode a 10GB file into memory all at once).
@@ -85,113 +83,44 @@ pub enum BlockDecodingStrategy {
     UptoBytes(usize),
 }
 
-#[derive(Debug)]
+#[derive(Debug, derive_more::Display, derive_more::From)]
+#[cfg_attr(feature = "std", derive(derive_more::Error))]
 #[non_exhaustive]
 pub enum FrameDecoderError {
+    #[display(fmt = "{_0:?}")]
+    #[from]
     ReadFrameHeaderError(frame::ReadFrameHeaderError),
+    #[display(fmt = "{_0:?}")]
+    #[from]
     FrameHeaderError(frame::FrameHeaderError),
+    #[display(
+        fmt = "Specified window_size is too big; Requested: {requested}, Max: {MAX_WINDOW_SIZE}"
+    )]
     WindowSizeTooBig { requested: u64 },
+    #[display(fmt = "{_0:?}")]
+    #[from]
     DictionaryDecodeError(dictionary::DictionaryDecodeError),
+    #[display(fmt = "Failed to parse/decode block body: {_0}")]
+    #[from]
     FailedToReadBlockHeader(decoding::block_decoder::BlockHeaderReadError),
+    #[display(fmt = "Failed to parse block header: {_0}")]
     FailedToReadBlockBody(decoding::block_decoder::DecodeBlockContentError),
+    #[display(fmt = "Failed to read checksum: {_0}")]
     FailedToReadChecksum(Error),
+    #[display(fmt = "Decoder must initialized or reset before using it")]
     NotYetInitialized,
+    #[display(fmt = "Decoder encountered error while initializing: {_0}")]
     FailedToInitialize(frame::FrameHeaderError),
+    #[display(fmt = "Decoder encountered error while draining the decodebuffer: {_0}")]
     FailedToDrainDecodebuffer(Error),
+    #[display(
+        fmt = "Target must have at least as many bytes as the contentsize of the frame reports"
+    )]
     TargetTooSmall,
+    #[display(
+        fmt = "Frame header specified dictionary id 0x{dict_id:X} that wasnt provided by add_dict() or reset_with_dict()"
+    )]
     DictNotProvided { dict_id: u32 },
-}
-
-#[cfg(feature = "std")]
-impl StdError for FrameDecoderError {
-    fn source(&self) -> Option<&(dyn StdError + 'static)> {
-        match self {
-            FrameDecoderError::ReadFrameHeaderError(source) => Some(source),
-            FrameDecoderError::FrameHeaderError(source) => Some(source),
-            FrameDecoderError::DictionaryDecodeError(source) => Some(source),
-            FrameDecoderError::FailedToReadBlockHeader(source) => Some(source),
-            FrameDecoderError::FailedToReadBlockBody(source) => Some(source),
-            FrameDecoderError::FailedToReadChecksum(source) => Some(source),
-            FrameDecoderError::FailedToInitialize(source) => Some(source),
-            FrameDecoderError::FailedToDrainDecodebuffer(source) => Some(source),
-            _ => None,
-        }
-    }
-}
-
-impl core::fmt::Display for FrameDecoderError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        match self {
-            FrameDecoderError::ReadFrameHeaderError(e) => {
-                write!(f, "{:?}", e)
-            }
-            FrameDecoderError::FrameHeaderError(e) => {
-                write!(f, "{:?}", e)
-            }
-            FrameDecoderError::WindowSizeTooBig { requested } => {
-                write!(
-                    f,
-                    "Specified window_size is too big; Requested: {}, Max: {}",
-                    requested, MAX_WINDOW_SIZE,
-                )
-            }
-            FrameDecoderError::DictionaryDecodeError(e) => {
-                write!(f, "{:?}", e)
-            }
-            FrameDecoderError::FailedToReadBlockHeader(e) => {
-                write!(f, "Failed to parse/decode block body: {}", e)
-            }
-            FrameDecoderError::FailedToReadBlockBody(e) => {
-                write!(f, "Failed to parse block header: {}", e)
-            }
-            FrameDecoderError::FailedToReadChecksum(e) => {
-                write!(f, "Failed to read checksum: {}", e)
-            }
-            FrameDecoderError::NotYetInitialized => {
-                write!(f, "Decoder must initialized or reset before using it",)
-            }
-            FrameDecoderError::FailedToInitialize(e) => {
-                write!(f, "Decoder encountered error while initializing: {}", e)
-            }
-            FrameDecoderError::FailedToDrainDecodebuffer(e) => {
-                write!(
-                    f,
-                    "Decoder encountered error while draining the decodebuffer: {}",
-                    e,
-                )
-            }
-            FrameDecoderError::TargetTooSmall => {
-                write!(f, "Target must have at least as many bytes as the contentsize of the frame reports")
-            }
-            FrameDecoderError::DictNotProvided { dict_id } => {
-                write!(f, "Frame header specified dictionary id 0x{:X} that wasnt provided by add_dict() or reset_with_dict()", dict_id)
-            }
-        }
-    }
-}
-
-impl From<dictionary::DictionaryDecodeError> for FrameDecoderError {
-    fn from(val: dictionary::DictionaryDecodeError) -> Self {
-        Self::DictionaryDecodeError(val)
-    }
-}
-
-impl From<decoding::block_decoder::BlockHeaderReadError> for FrameDecoderError {
-    fn from(val: decoding::block_decoder::BlockHeaderReadError) -> Self {
-        Self::FailedToReadBlockHeader(val)
-    }
-}
-
-impl From<frame::FrameHeaderError> for FrameDecoderError {
-    fn from(val: frame::FrameHeaderError) -> Self {
-        Self::FrameHeaderError(val)
-    }
-}
-
-impl From<frame::ReadFrameHeaderError> for FrameDecoderError {
-    fn from(val: frame::ReadFrameHeaderError) -> Self {
-        Self::ReadFrameHeaderError(val)
-    }
 }
 
 const MAX_WINDOW_SIZE: u64 = 1024 * 1024 * 100;

--- a/src/huff0/huff0_decoder.rs
+++ b/src/huff0/huff0_decoder.rs
@@ -3,8 +3,6 @@
 use crate::decoding::bit_reader_reverse::{BitReaderReversed, GetBitsError};
 use crate::fse::{FSEDecoder, FSEDecoderError, FSETable, FSETableError};
 use alloc::vec::Vec;
-#[cfg(feature = "std")]
-use std::error::Error as StdError;
 
 pub struct HuffmanTable {
     decode: Vec<Entry>,
@@ -24,151 +22,56 @@ pub struct HuffmanTable {
     fse_table: FSETable,
 }
 
-#[derive(Debug)]
+#[derive(Debug, derive_more::Display, derive_more::From)]
+#[cfg_attr(feature = "std", derive(derive_more::Error))]
 #[non_exhaustive]
 pub enum HuffmanTableError {
+    #[display(fmt = "{_0:?}")]
+    #[from]
     GetBitsError(GetBitsError),
+    #[display(fmt = "{_0:?}")]
+    #[from]
     FSEDecoderError(FSEDecoderError),
+    #[display(fmt = "{_0:?}")]
+    #[from]
     FSETableError(FSETableError),
+    #[display(fmt = "Source needs to have at least one byte")]
     SourceIsEmpty,
+    #[display(
+        fmt = "Header says there should be {expected_bytes} bytes for the weights but there are only {got_bytes} bytes in the stream"
+    )]
     NotEnoughBytesForWeights {
         got_bytes: usize,
         expected_bytes: u8,
     },
-    ExtraPadding {
-        skipped_bits: i32,
-    },
-    TooManyWeights {
-        got: usize,
-    },
+    #[display(
+        fmt = "Padding at the end of the sequence_section was more than a byte long: {skipped_bits} bits. Probably caused by data corruption"
+    )]
+    ExtraPadding { skipped_bits: i32 },
+    #[display(
+        fmt = "More than 255 weights decoded (got {got} weights). Stream is probably corrupted"
+    )]
+    TooManyWeights { got: usize },
+    #[display(fmt = "Can't build huffman table without any weights")]
     MissingWeights,
-    LeftoverIsNotAPowerOf2 {
-        got: u32,
-    },
-    NotEnoughBytesToDecompressWeights {
-        have: usize,
-        need: usize,
-    },
-    FSETableUsedTooManyBytes {
-        used: usize,
-        available_bytes: u8,
-    },
-    NotEnoughBytesInSource {
-        got: usize,
-        need: usize,
-    },
-    WeightBiggerThanMaxNumBits {
-        got: u8,
-    },
-    MaxBitsTooHigh {
-        got: u8,
-    },
-}
-
-#[cfg(feature = "std")]
-impl StdError for HuffmanTableError {
-    fn source(&self) -> Option<&(dyn StdError + 'static)> {
-        match self {
-            HuffmanTableError::GetBitsError(source) => Some(source),
-            HuffmanTableError::FSEDecoderError(source) => Some(source),
-            HuffmanTableError::FSETableError(source) => Some(source),
-            _ => None,
-        }
-    }
-}
-
-impl core::fmt::Display for HuffmanTableError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        match self {
-            HuffmanTableError::GetBitsError(e) => write!(f, "{:?}", e),
-            HuffmanTableError::FSEDecoderError(e) => write!(f, "{:?}", e),
-            HuffmanTableError::FSETableError(e) => write!(f, "{:?}", e),
-            HuffmanTableError::SourceIsEmpty => write!(f, "Source needs to have at least one byte"),
-            HuffmanTableError::NotEnoughBytesForWeights {
-                got_bytes,
-                expected_bytes,
-            } => {
-                write!(f, "Header says there should be {} bytes for the weights but there are only {} bytes in the stream",
-                    expected_bytes,
-                    got_bytes)
-            }
-            HuffmanTableError::ExtraPadding { skipped_bits } => {
-                write!(f,
-                    "Padding at the end of the sequence_section was more than a byte long: {} bits. Probably caused by data corruption",
-                    skipped_bits,
-                )
-            }
-            HuffmanTableError::TooManyWeights { got } => {
-                write!(
-                    f,
-                    "More than 255 weights decoded (got {} weights). Stream is probably corrupted",
-                    got,
-                )
-            }
-            HuffmanTableError::MissingWeights => {
-                write!(f, "Can\'t build huffman table without any weights")
-            }
-            HuffmanTableError::LeftoverIsNotAPowerOf2 { got } => {
-                write!(f, "Leftover must be power of two but is: {}", got)
-            }
-            HuffmanTableError::NotEnoughBytesToDecompressWeights { have, need } => {
-                write!(
-                    f,
-                    "Not enough bytes in stream to decompress weights. Is: {}, Should be: {}",
-                    have, need,
-                )
-            }
-            HuffmanTableError::FSETableUsedTooManyBytes {
-                used,
-                available_bytes,
-            } => {
-                write!(f,
-                    "FSE table used more bytes: {} than were meant to be used for the whole stream of huffman weights ({})",
-                    used,
-                    available_bytes,
-                )
-            }
-            HuffmanTableError::NotEnoughBytesInSource { got, need } => {
-                write!(
-                    f,
-                    "Source needs to have at least {} bytes, got: {}",
-                    need, got,
-                )
-            }
-            HuffmanTableError::WeightBiggerThanMaxNumBits { got } => {
-                write!(
-                    f,
-                    "Cant have weight: {} bigger than max_num_bits: {}",
-                    got, MAX_MAX_NUM_BITS,
-                )
-            }
-            HuffmanTableError::MaxBitsTooHigh { got } => {
-                write!(
-                    f,
-                    "max_bits derived from weights is: {} should be lower than: {}",
-                    got, MAX_MAX_NUM_BITS,
-                )
-            }
-        }
-    }
-}
-
-impl From<GetBitsError> for HuffmanTableError {
-    fn from(val: GetBitsError) -> Self {
-        Self::GetBitsError(val)
-    }
-}
-
-impl From<FSEDecoderError> for HuffmanTableError {
-    fn from(val: FSEDecoderError) -> Self {
-        Self::FSEDecoderError(val)
-    }
-}
-
-impl From<FSETableError> for HuffmanTableError {
-    fn from(val: FSETableError) -> Self {
-        Self::FSETableError(val)
-    }
+    #[display(fmt = "Leftover must be power of two but is: {got}")]
+    LeftoverIsNotAPowerOf2 { got: u32 },
+    #[display(
+        fmt = "Not enough bytes in stream to decompress weights. Is: {have}, Should be: {need}"
+    )]
+    NotEnoughBytesToDecompressWeights { have: usize, need: usize },
+    #[display(
+        fmt = "FSE table used more bytes: {used} than were meant to be used for the whole stream of huffman weights ({available_bytes})"
+    )]
+    FSETableUsedTooManyBytes { used: usize, available_bytes: u8 },
+    #[display(fmt = "Source needs to have at least {need} bytes, got: {got}")]
+    NotEnoughBytesInSource { got: usize, need: usize },
+    #[display(fmt = "Cant have weight: {got} bigger than max_num_bits: {MAX_MAX_NUM_BITS}")]
+    WeightBiggerThanMaxNumBits { got: u8 },
+    #[display(
+        fmt = "max_bits derived from weights is: {got} should be lower than: {MAX_MAX_NUM_BITS}"
+    )]
+    MaxBitsTooHigh { got: u8 },
 }
 
 /// An interface around a huffman table used to decode data.
@@ -178,33 +81,13 @@ pub struct HuffmanDecoder<'table> {
     pub state: u64,
 }
 
-#[derive(Debug)]
+#[derive(Debug, derive_more::Display, derive_more::From)]
+#[cfg_attr(feature = "std", derive(derive_more::Error))]
 #[non_exhaustive]
 pub enum HuffmanDecoderError {
+    #[display(fmt = "{_0:?}")]
+    #[from]
     GetBitsError(GetBitsError),
-}
-
-impl core::fmt::Display for HuffmanDecoderError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            HuffmanDecoderError::GetBitsError(e) => write!(f, "{:?}", e),
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl StdError for HuffmanDecoderError {
-    fn source(&self) -> Option<&(dyn StdError + 'static)> {
-        match self {
-            HuffmanDecoderError::GetBitsError(source) => Some(source),
-        }
-    }
-}
-
-impl From<GetBitsError> for HuffmanDecoderError {
-    fn from(val: GetBitsError) -> Self {
-        Self::GetBitsError(val)
-    }
 }
 
 /// A single entry in the table contains the decoded symbol/literal and the


### PR DESCRIPTION
This reverts commit 5265c12c8cdc03647b90ae89fd3b64015a1c2d8c.

The just released `derive_more` v0.99.18 uses syn 2.x instead of syn 1.x,
removing the conflict with other dependencies.
