### PR TITLE
Upgrade to twox-hash 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["zstd", "zstandard", "decompression"]
 categories = ["compression"]
 
 [dependencies]
-twox-hash = { version = "1.6", default-features = false, optional = true }
+twox-hash = { version = "2.0", default-features = false, features = ["xxhash64"], optional = true }
 
 # Internal feature, only used when building as part of libstd, not part of the
 # stable interface of this crate.


### PR DESCRIPTION
Thanks for using my crate!

Note that version 2.0 increases the MSRV to Rust 1.81. I understand if you don't want to upgrade right away, but hopefully this PR will be useful when you do.

I'm opening these PRs for the top users of twox-hash and have no current plans to become a consistent contributor to this specific repository; please feel free to rewrite the commit as appropriate for your project's requirements.