### PR TITLE
Fix `RingBuffer::extend_from_within_unchecked` unsoundness

### DIFF
--- a/src/decoding/ringbuffer.rs
+++ b/src/decoding/ringbuffer.rs
@@ -295,6 +295,9 @@ impl RingBuffer {
     /// 2. More then len reserved space so we do not write out-of-bounds
     #[warn(unsafe_op_in_unsafe_fn)]
     pub unsafe fn extend_from_within_unchecked(&mut self, start: usize, len: usize) {
+        debug_assert!(start + len <= self.len());
+        debug_assert!(self.free() >= len);
+
         if self.head < self.tail {
             // Continuous source section and possibly non continuous write section:
             //

--- a/src/decoding/ringbuffer.rs
+++ b/src/decoding/ringbuffer.rs
@@ -301,7 +301,7 @@ impl RingBuffer {
             unsafe {
                 let src = (
                     self.buf.as_ptr().cast_const().add(self.head + start),
-                    self.tail - self.head,
+                    self.tail - self.head - start,
                 );
                 let dst = (self.buf.as_ptr().add(self.tail), self.cap - self.tail);
                 copy_bytes_overshooting(src, dst, after_tail);
@@ -317,10 +317,7 @@ impl RingBuffer {
             if self.head + start > self.cap {
                 let start = (self.head + start) % self.cap;
                 unsafe {
-                    let src = (
-                        self.buf.as_ptr().add(start).cast_const(),
-                        self.cap - self.head,
-                    );
+                    let src = (self.buf.as_ptr().add(start).cast_const(), self.tail - start);
                     let dst = (self.buf.as_ptr().add(self.tail), self.head - self.tail);
                     copy_bytes_overshooting(src, dst, len);
                 }
@@ -329,7 +326,7 @@ impl RingBuffer {
                 unsafe {
                     let src = (
                         self.buf.as_ptr().add(self.head + start).cast_const(),
-                        self.cap - self.head,
+                        self.cap - self.head - start,
                     );
                     let dst = (self.buf.as_ptr().add(self.tail), self.head - self.tail);
                     copy_bytes_overshooting(src, dst, after_start);


### PR DESCRIPTION
This fixes the unsoundness reported in #75 by correcting the `src` length math. Also adds safety and general comments, making it much easier to understand the logic.

The first commit fixes the vulnerability while the other commits cleanup the implementation and add two unrelated debug assertions.

Fixes #75