### PR TITLE
Representative fuzzing harness

### DIFF
--- a/fuzz/fuzz_targets/decode.rs
+++ b/fuzz/fuzz_targets/decode.rs
@@ -1,16 +1,11 @@
 #![no_main]
 #[macro_use] extern crate libfuzzer_sys;
 extern crate ruzstd;
-use ruzstd::frame_decoder;
+use std::io::Read;
 
 fuzz_target!(|data: &[u8]| {
-    let mut content = data;
-    let mut frame_dec = frame_decoder::FrameDecoder::new();
-
-    match frame_dec.reset(&mut content){
-        Ok(_) => {
-            let _ = frame_dec.decode_blocks(&mut content,frame_decoder::BlockDecodingStrategy::All);
-        }
-        Err(_) => {/* nothing */}
+    if let Ok(mut decoder) = ruzstd::StreamingDecoder::new(data) {
+        let mut output = Vec::new();
+        _ = decoder.read_to_end(&mut output);
     }
 });


### PR DESCRIPTION
Make the fuzzing harness more representative of real-world code. It can now find #75 in under a minute when fed zstd's [official fuzzing seeds](https://github.com/facebook/zstd/blob/dev/tests/fuzz/README.md).