### PR TITLE
refactor: move compress_fastest to a new file

### DIFF
--- a/src/encoding/levels/fastest.rs
+++ b/src/encoding/levels/fastest.rs
@@ -1,0 +1,67 @@
+use crate::{
+    common::MAX_BLOCK_SIZE,
+    encoding::{
+        block_header::BlockHeader, blocks::compress_block, frame_compressor::CompressState, Matcher,
+    },
+};
+use alloc::vec::Vec;
+
+/// Compresses a single block at [`crate::encoding::CompressionLevel::Fastest`].
+///
+/// # Parameters
+/// - `state`: [`CompressState`] so the compressor can refer to data before
+///   the start of this block
+/// - `last_block`: Whether or not this block is going to be the last block in the frame
+///   (needed because this info is written into the block header)
+/// - `uncompressed_data`: A block's worth of uncompressed data, taken from the
+///   larger input
+/// - `output`: As `uncompressed_data` is compressed, it's appended to `output`.
+#[inline]
+pub fn compress_fastest<M: Matcher>(
+    state: &mut CompressState<M>,
+    last_block: bool,
+    uncompressed_data: Vec<u8>,
+    output: &mut Vec<u8>,
+) {
+    let block_size = uncompressed_data.len() as u32;
+    // First check to see if run length encoding can be used for the entire block
+    if uncompressed_data.iter().all(|x| uncompressed_data[0].eq(x)) {
+        let rle_byte = uncompressed_data[0];
+        state.matcher.commit_space(uncompressed_data);
+        state.matcher.skip_matching();
+        let header = BlockHeader {
+            last_block,
+            block_type: crate::blocks::block::BlockType::RLE,
+            block_size,
+        };
+        // Write the header, then the block
+        header.serialize(output);
+        output.push(rle_byte);
+    } else {
+        // Compress as a standard compressed block
+        let mut compressed = Vec::new();
+        state.matcher.commit_space(uncompressed_data);
+        compress_block(state, &mut compressed);
+        // If the compressed data is larger than the maximum
+        // allowable block size, instead store uncompressed
+        if compressed.len() >= MAX_BLOCK_SIZE as usize {
+            let header = BlockHeader {
+                last_block,
+                block_type: crate::blocks::block::BlockType::Raw,
+                block_size,
+            };
+            // Write the header, then the block
+            header.serialize(output);
+            output.extend_from_slice(state.matcher.get_last_space());
+        } else {
+            let header = BlockHeader {
+                last_block,
+                block_type: crate::blocks::block::BlockType::Compressed,
+                block_size: compressed.len() as u32,
+            };
+            // Write the header, then the block
+            header.serialize(output);
+            output.extend(compressed);
+        }
+    }
+}

--- a/src/encoding/levels/mod.rs
+++ b/src/encoding/levels/mod.rs
@@ -1,0 +1,2 @@
+mod fastest;
+pub use fastest::compress_fastest;

--- a/src/encoding/mod.rs
+++ b/src/encoding/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod match_generator;
 pub(crate) mod util;
 
 mod frame_compressor;
+mod levels;
 pub use frame_compressor::FrameCompressor;
 
 use crate::io::{Read, Write};
@@ -68,7 +69,8 @@ pub enum CompressionLevel {
 /// making their own tradeoffs between runtime, memory usage and compression ratio
 ///
 /// This trait operates on buffers that represent the chunks of data the matching algorithm wants to work on.
-/// One or more of these buffers represent the window the decoder will need to decode the data again.
+/// Each one of these buffers is referred to as a *space*. One or more of these buffers represent the window
+/// the decoder will need to decode the data again.
 ///
 /// This library asks the Matcher for a new buffer using `get_next_space` to allow reusing of allocated buffers when they are no longer part of the
 /// window of data that is being used for matching.


### PR DESCRIPTION
This change creates a new folder `./levels`, ideally where each compression level would have its own file.

I believe this change will help keep things simple, and make addition of more compression levels easier.