### PR TITLE
Expose decoding::Dictionary

### DIFF
--- a/ruzstd/src/decoding/mod.rs
+++ b/ruzstd/src/decoding/mod.rs
@@ -6,6 +6,7 @@ mod streaming_decoder;
 
 pub use frame_decoder::{BlockDecodingStrategy, FrameDecoder};
 pub use streaming_decoder::StreamingDecoder;
+pub use dictionary::Dictionary;
 
 pub(crate) mod block_decoder;
 pub(crate) mod decode_buffer;


### PR DESCRIPTION
So that a existing dictionary can be decoded and used in ~FrameDecoder::set_dict~ [FrameDecoder::add_dict](https://docs.rs/ruzstd/latest/ruzstd/decoding/struct.FrameDecoder.html#method.add_dict)