### PR TITLE
Add `small-stack` feature to shrink Raw block stack buffer

### DIFF
--- a/ruzstd/Cargo.toml
+++ b/ruzstd/Cargo.toml
@@ -35,6 +35,11 @@ dict_builder = ["std", "dep:fastrand"]
 hash = ["dep:twox-hash"]
 fuzz_exports = []
 std = []
+# Reduce the stack buffer used when streaming Raw blocks from 128 KiB to 1 KiB.
+# Targets deeply embedded platforms (e.g. Xtensa ESP32 tasks with ~40 KiB
+# stacks) where the default would overflow. Comes at a small throughput cost
+# for Raw-heavy streams due to more read/push iterations.
+small-stack = []
 
 # Internal feature, only used when building as part of libstd, not part of the
 # stable interface of this crate.

--- a/ruzstd/src/decoding/block_decoder.rs
+++ b/ruzstd/src/decoding/block_decoder.rs
@@ -79,7 +79,15 @@ impl BlockDecoder {
                 Ok(1)
             }
             BlockType::Raw => {
+                // On deeply embedded targets (e.g. Xtensa ESP32 tasks with
+                // ~40 KiB stacks), the default 128 KiB stack buffer overflows
+                // the task stack. The `small-stack` feature shrinks it to
+                // 1 KiB at the cost of more read/push iterations per block.
+                #[cfg(not(feature = "small-stack"))]
                 const BATCH_SIZE: usize = 128 * 1024;
+                #[cfg(feature = "small-stack")]
+                const BATCH_SIZE: usize = 1024;
+
                 let mut buf = [0u8; BATCH_SIZE];
                 let full_reads = header.decompressed_size / BATCH_SIZE as u32;
                 let single_read_size = header.decompressed_size % BATCH_SIZE as u32;


### PR DESCRIPTION
## Add `small-stack` feature to shrink Raw block stack buffer

### Summary
- The `Raw` block path in [BlockDecoder::decode_block_content](ruzstd/src/decoding/block_decoder.rs#L79) allocates a 128 KiB buffer on the stack to batch-read raw block content. LLVM reserves that frame at function entry, so any stream containing a Raw block blows the stack the moment decoding hits that branch, regardless of the block's actual size.
- On deeply embedded targets this is fatal. Xtensa ESP32 tasks, for example, typically run with ~40 KiB executor stacks, and a 128 KiB frame overflows immediately.
- Adds a new **`small-stack`** cargo feature (off by default) that shrinks `BATCH_SIZE` from `128 * 1024` to `1024`. The surrounding loop already handles arbitrarily-sized blocks, so the only cost is extra read/push iterations for Raw-heavy streams on platforms that opt in.

### Changes
- [ruzstd/Cargo.toml](ruzstd/Cargo.toml) - declare the `small-stack` feature with a comment explaining its purpose and tradeoff.
- [ruzstd/src/decoding/block_decoder.rs:79-89](ruzstd/src/decoding/block_decoder.rs#L79-L89) - gate `BATCH_SIZE` on `cfg(feature = "small-stack")`.

### Compatibility
- Default behavior is unchanged - the feature is opt-in and the constant stays at 128 KiB unless explicitly enabled.
- No public API changes.

### Tests
- [x] `cargo test -p ruzstd` (default features)
- [x] `cargo test -p ruzstd --features small-stack`
- [x] `cargo build -p ruzstd --no-default-features --features small-stack` to confirm the feature composes with `no_std` builds
- [x] Spot-check a Raw-block-heavy fixture with `small-stack` enabled to confirm correctness of the smaller batching loop


----



The cargo feature approach seemed least invasive, however, I'm happy to rework this. Here are some alternative approaches i considered;

1. **Heap-allocate the buffer instead of stack.** Replace the `[u8; BATCH_SIZE]` array with a `Vec<u8>` (or `Box<[u8]>`) when `alloc`/`std` is available. This sidesteps the stack-frame issue entirely without a new feature flag, but it costs an allocation per Raw block and isn't viable for `no_std` + no-`alloc` users.

2. **Shrink the default unconditionally.** 1 KiB (or some middle ground like 4-8 KiB) as the default for everyone. Simpler - no feature flag, no cfg - but it's a throughput regression for the common desktop/server case on Raw-heavy streams, which is why I went with opt-in.

3. **Make `BATCH_SIZE` a generic const / associated const on a trait.** Lets callers pick their own size without a cargo feature. More flexible but a bigger API surface change, and probably overkill for a single internal buffer.

4. **Read directly into the output sink in smaller chunks without any intermediate buffer.** Would require reshaping the loop around the `Read` + sink APIs; I didn't want to touch that without a signal from you that it's welcome.

5. **Different feature name.** `small-stack` felt descriptive, but `embedded`, `tiny-stack`, or `no-large-stack-buffers` would all work. Let me know if you have a preferred convention.