### PR TITLE
derive debug trait for compression level

### DIFF
--- a/ruzstd/src/encoding/mod.rs
+++ b/ruzstd/src/encoding/mod.rs
@@ -43,7 +43,7 @@ pub fn compress_to_vec<R: Read>(source: R, level: CompressionLevel) -> Vec<u8> {
 /// The compression mode used impacts the speed of compression,
 /// and resulting compression ratios. Faster compression will result
 /// in worse compression ratios, and vice versa.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub enum CompressionLevel {
     /// This level does not compress the data at all, and simply wraps
     /// it in a Zstandard frame.


### PR DESCRIPTION
I wanted to use it in a registry that wants to print itself, but was blocked by this.

I think it makes sense to be able to print decoding level, Debug was used elsewhere in the code and it's a rather primitive struct, so I thought this was the easiest way in - as opposed to making an issue and everything :).