### PR TITLE
Avoid expanding incompressible fastest blocks

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,9 @@ This document records the changes made between versions, starting with version 0
 
 # After 0.8.3 (Current)
 
+* Avoid emitting compressed blocks when the compressed payload is not smaller
+  than the raw block.
+
 # After 0.8.2
 * Introduce the `rust-version` field
 * Fix checksum generation when repeatedly using the encoder

--- a/ruzstd/examples/compression_ratio.rs
+++ b/ruzstd/examples/compression_ratio.rs
@@ -1,0 +1,49 @@
+use std::time::Instant;
+
+use ruzstd::encoding::{compress_to_vec, CompressionLevel};
+
+const ITERATIONS: usize = 50;
+
+fn main() {
+    let fixtures = [
+        ("zeros_128k", zeros(128 * 1024)),
+        ("repeated_text_128k", repeated_text(128 * 1024)),
+        ("xorshift_8k", xorshift(8 * 1024)),
+        ("xorshift_64k", xorshift(64 * 1024)),
+        ("xorshift_128k", xorshift(128 * 1024)),
+        ("xorshift_256k", xorshift(256 * 1024)),
+    ];
+
+    println!("fixture,input_bytes,compressed_bytes,avg_nanos");
+    for (name, data) in fixtures {
+        let mut compressed = Vec::new();
+        let started = Instant::now();
+        for _ in 0..ITERATIONS {
+            compressed = compress_to_vec(data.as_slice(), CompressionLevel::Fastest);
+        }
+        let avg_nanos = started.elapsed().as_nanos() / ITERATIONS as u128;
+        println!("{name},{},{},{avg_nanos}", data.len(), compressed.len());
+    }
+}
+
+fn zeros(len: usize) -> Vec<u8> {
+    vec![0; len]
+}
+
+fn repeated_text(len: usize) -> Vec<u8> {
+    let phrase = b"systemd-journald.service After=systemd-journald-dev-log.socket\n";
+    phrase.iter().copied().cycle().take(len).collect()
+}
+
+fn xorshift(len: usize) -> Vec<u8> {
+    let mut state = 0x1234_5678_9ABC_DEF0u64;
+    let mut data = Vec::with_capacity(len);
+    while data.len() < len {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        data.extend_from_slice(&state.to_le_bytes());
+    }
+    data.truncate(len);
+    data
+}

--- a/ruzstd/src/encoding/levels/fastest.rs
+++ b/ruzstd/src/encoding/levels/fastest.rs
@@ -42,9 +42,11 @@ pub fn compress_fastest<M: Matcher>(
         let mut compressed = Vec::new();
         state.matcher.commit_space(uncompressed_data);
         compress_block(state, &mut compressed);
-        // If the compressed data is larger than the maximum
-        // allowable block size, instead store uncompressed
-        if compressed.len() >= MAX_BLOCK_SIZE as usize {
+        let compressed_size = compressed.len();
+        // If compression does not shrink the block, store it raw instead.
+        // Also preserve the format guard that compressed blocks must not
+        // exceed the maximum block size.
+        if compressed_size >= block_size as usize || compressed_size > MAX_BLOCK_SIZE as usize {
             let header = BlockHeader {
                 last_block,
                 block_type: crate::blocks::block::BlockType::Raw,
@@ -57,7 +59,7 @@ pub fn compress_fastest<M: Matcher>(
             let header = BlockHeader {
                 last_block,
                 block_type: crate::blocks::block::BlockType::Compressed,
-                block_size: compressed.len() as u32,
+                block_size: compressed_size as u32,
             };
             // Write the header, then the block
             header.serialize(output);

--- a/ruzstd/src/encoding/levels/fastest_tests.rs
+++ b/ruzstd/src/encoding/levels/fastest_tests.rs
@@ -1,0 +1,39 @@
+use alloc::vec::Vec;
+
+use crate::encoding::{compress_to_vec, CompressionLevel};
+
+#[test]
+fn fastest_does_not_expand_incompressible_blocks_past_raw_size() {
+    assert_fastest_does_not_exceed_raw(8 * 1024);
+}
+
+#[test]
+fn fastest_does_not_expand_incompressible_max_size_blocks() {
+    assert_fastest_does_not_exceed_raw(128 * 1024);
+}
+
+fn assert_fastest_does_not_exceed_raw(len: usize) {
+    let data = xorshift(len);
+    let raw = compress_to_vec(data.as_slice(), CompressionLevel::Uncompressed);
+    let fastest = compress_to_vec(data.as_slice(), CompressionLevel::Fastest);
+
+    assert!(
+        fastest.len() <= raw.len(),
+        "fastest output should not exceed raw frame size for {len} bytes: {} > {}",
+        fastest.len(),
+        raw.len()
+    );
+}
+
+fn xorshift(len: usize) -> Vec<u8> {
+    let mut state = 0x1234_5678_9ABC_DEF0u64;
+    let mut data = Vec::with_capacity(len);
+    while data.len() < len {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        data.extend_from_slice(&state.to_le_bytes());
+    }
+    data.truncate(len);
+    data
+}

--- a/ruzstd/src/encoding/levels/mod.rs
+++ b/ruzstd/src/encoding/levels/mod.rs
@@ -1,2 +1,4 @@
 mod fastest;
+#[cfg(test)]
+mod fastest_tests;
 pub use fastest::compress_fastest;


### PR DESCRIPTION
now checks that a block was reduced in size. If not we use the uncompressed block.

AI generated code changes - human reviewed.