### PR TITLE
Remove `compiler-builtins` from `rustc-dep-of-std` dependencies

### DIFF
--- a/ruzstd/Cargo.toml
+++ b/ruzstd/Cargo.toml
@@ -20,7 +20,6 @@ fastrand = {version = "2.3.0", optional = true }
 
 # Internal feature, only used when building as part of libstd, not part of the
 # stable interface of this crate.
-compiler_builtins = { version = "0.1.2", optional = true }
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
 alloc = { version = "1.0.0", optional = true, package = "rustc-std-workspace-alloc" }
 
@@ -38,7 +37,7 @@ std = []
 
 # Internal feature, only used when building as part of libstd, not part of the
 # stable interface of this crate.
-rustc-dep-of-std = ["dep:compiler_builtins", "dep:core", "dep:alloc"]
+rustc-dep-of-std = ["dep:core", "dep:alloc"]
 
 [[bench]]
 name = "decode_all"


### PR DESCRIPTION
Since [1], this will come automatically from `rustc-std-workspace-core` and the crates.io dependency should no longer be specified.

[1]: https://github.com/rust-lang/rust/pull/141993