### PR TITLE
Avoid u32 underflow on repeat-offset from a malformed dictionary

### DIFF
--- a/ruzstd/src/decoding/sequence_execution.rs
+++ b/ruzstd/src/decoding/sequence_execution.rs
@@ -68,7 +68,10 @@ fn do_offset_history(offset_value: u32, lit_len: u32, scratch: &mut [u32; 3]) ->
     } else {
         match offset_value {
             1..=2 => scratch[offset_value as usize],
-            3 => scratch[0] - 1,
+            // A malformed dictionary can seed scratch[0] with 0; saturate so this
+            // resolves to 0 (rejected upstream as ZeroOffset) instead of
+            // underflowing. See #115.
+            3 => scratch[0].saturating_sub(1),
             _ => {
                 //new offset
                 offset_value - 3
@@ -112,4 +115,20 @@ fn do_offset_history(offset_value: u32, lit_len: u32, scratch: &mut [u32; 3]) ->
     }
 
     actual_offset
+}
+
+#[cfg(test)]
+mod tests {
+    use super::do_offset_history;
+
+    #[test]
+    fn repeat_offset_minus_one_with_zero_history_does_not_underflow() {
+        // A malformed dictionary can seed offset history slot 0 with 0. With
+        // literal length 0 and offset code 3 ("repeat the most recent offset,
+        // minus one"), `scratch[0] - 1` must not underflow; it should resolve to
+        // 0, which the caller rejects as ExecuteSequencesError::ZeroOffset rather
+        // than panicking (debug) or wrapping to u32::MAX (release). See #115.
+        let mut scratch = [0u32, 4, 8];
+        assert_eq!(do_offset_history(3, 0, &mut scratch), 0);
+    }
 }


### PR DESCRIPTION
### Summary

Fixes #115. Decompressing with a malformed dictionary can panic (debug) / wrap to `u32::MAX` (release) via an unchecked `u32` subtraction.

### Root cause

`do_offset_history` (`sequence_execution.rs`) handles offset code `3` with literal length `0` ("repeat the most recent offset, minus one"):

```rust
3 => scratch[0] - 1,
```

`scratch` is the offset history, seeded from the dictionary (`scratch.rs` copies `dict.offset_hist`). A malformed dictionary can set slot 0 to `0`, so `scratch[0] - 1` underflows — a panic in debug builds, a wrap to `u32::MAX` in release. This is reachable from the normal decompress-with-dictionary path (`execute_sequences` → `do_offset_history`), matching the reporter's repro.

### Fix

```rust
3 => scratch[0].saturating_sub(1),
```

When `scratch[0] == 0`, the offset resolves to `0`, which `execute_sequences` already rejects a few lines up as `ExecuteSequencesError::ZeroOffset` — the intended "corrupted data" outcome (the crate's own comment in `sequence_section.rs` notes an offset of 0 here means the data is corrupted). Valid offsets (`scratch[0] >= 1`) are unchanged, since `saturating_sub` equals plain subtraction there. The sibling `_ => offset_value - 3` arm can't underflow: `offset == 0` is already rejected upstream (`sequence_section_decoder.rs`), so that arm only runs for `offset_value >= 4`.

### Test

Added a unit test that calls `do_offset_history(3, 0, &mut [0, 4, 8])` and asserts it returns `0` without underflowing.

- Before the fix: panics `attempt to subtract with overflow` at `sequence_execution.rs`.
- After the fix: passes.

### Verification (local, in Docker)

- `cargo test -p ruzstd` — 72 + 7 tests pass, 0 failures (new test included; no regressions).
- `cargo +nightly fmt --all -- --check` — clean.
- `cargo +nightly clippy --workspace -- -D warnings` (and `--no-default-features`) — clean.
