### PR TITLE
Fix libzstd compatibility issues with DEFAULT_MAX_WINDOW_SIZE

### DIFF
--- a/ruzstd/src/decoding/frame_decoder.rs
+++ b/ruzstd/src/decoding/frame_decoder.rs
@@ -16,10 +16,13 @@ use core::convert::TryInto;
 
 /// The default maximum window size, in bytes, that a [FrameDecoder] accepts.
 ///
-/// Defaults to 100mb to bound allocation for malformed or hostile frames. The
+/// Defaults to 128mb to bound allocation for malformed or hostile frames. The
 /// spec permits far larger windows, so raise the limit with
 /// [FrameDecoder::set_max_window_size] for input you trust.
-pub const DEFAULT_MAX_WINDOW_SIZE: u64 = 1024 * 1024 * 100;
+///
+/// See [ZSTD_d_maxWindowLog](https://github.com/facebook/zstd/wiki/Using-libzstd-in-a-memory-constrained-environment#zstd_d_maxwindowlog)
+/// for compatibility concerns.
+pub const DEFAULT_MAX_WINDOW_SIZE: u64 = 1024 * 1024 * 128;
 
 /// Low level Zstandard decoder that can be used to decompress frames with fine control over when and how many bytes are decoded.
 ///


### PR DESCRIPTION
The Arch Linux package `rust-1:1.97.1-1-x86_64.pkg.tar.zst` fails to decompress with ruzstd, but is processed without problems by pacman with libarchive.

This was traced to a mismatch in the default max window size, libzstd uses a default limit of 128MiB, which is higher than ruzstd's 100MiB. As long as this limit is never exercised everything works well, but libzstd default settings may compress data in a way that ruzstd can not decompress anymore.

This was discovered in repro-env development, as part of the Reproducible Builds project.

Debugged with help from @stoeckmann