### PR TITLE
Remove redundant conditional branches

### DIFF
--- a/ruzstd/src/tests/mod.rs
+++ b/ruzstd/src/tests/mod.rs
@@ -210,11 +210,7 @@ fn test_decode_from_to() {
     }
 
     let mut counter = 0;
-    let min = if original.len() < result.len() {
-        original.len()
-    } else {
-        result.len()
-    };
+    let min = result.len();
     for idx in 0..min {
         if original[idx] != result[idx] {
             counter += 1;
@@ -316,11 +312,7 @@ fn test_streaming() {
     }
 
     let mut counter = 0;
-    let min = if original.len() < result.len() {
-        original.len()
-    } else {
-        result.len()
-    };
+    let min = result.len();
     for idx in 0..min {
         if original[idx] != result[idx] {
             counter += 1;
@@ -360,11 +352,7 @@ fn test_streaming() {
     }
 
     let mut counter = 0;
-    let min = if original.len() < result.len() {
-        original.len()
-    } else {
-        result.len()
-    };
+    let min = result.len();
     for idx in 0..min {
         if original[idx] != result[idx] {
             counter += 1;
@@ -425,11 +413,7 @@ fn test_streaming_no_std() {
     }
 
     let mut counter = 0;
-    let min = if original.len() < result.len() {
-        original.len()
-    } else {
-        result.len()
-    };
+    let min = result.len();
     for idx in 0..min {
         if original[idx] != result[idx] {
             counter += 1;
@@ -468,11 +452,7 @@ fn test_streaming_no_std() {
     }
 
     let mut counter = 0;
-    let min = if original.len() < result.len() {
-        original.len()
-    } else {
-        result.len()
-    };
+    let min = result.len();
     for idx in 0..min {
         if original[idx] != result[idx] {
             counter += 1;


### PR DESCRIPTION
If I am not overlooking anything, I believe these branches are actually redundant.

That is because, before `if original.len() < result.len()`, there is an ` if original.len() != result.len() {
panic!()`, meaning that there are two possible paths: either `original.len() != result.len()` and there will be a panic, or `original.len() == result.len()`, meaning that we statically know that the if-statement will evaluate to `result.len()`.

For reference, these changes were found by an optimizer developed as a research project.

CC @nunoplopes